### PR TITLE
Add macos build & upgrade to curl 8.5

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,13 +30,8 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: recursive
-
-      - uses: actions/setup-python@v1
-        with:
-          python-version: '3.x'
-      - run: brew install gcc
-      - run: brew install meson
-      - run: brew install nlohmann-json
+      - run: brew install gcc meson
+      - run: brew install nlohmann-json sdl2
       - run: meson setup ${{github.workspace}}/build
         env:
           CC: gcc

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,31 +8,28 @@ on:
     - cron: '0 0 * * 6'
 
 jobs:
-  # build-ubuntu:
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #   - uses: actions/checkout@v3
-  #     with:
-  #       submodules: recursive
-
-  #   - name: Install various apt dependencies
-  #     run: sudo apt-get install build-essential cmake meson ninja-build nlohmann-json3-dev pkg-config libssl-dev libsdl2-dev
-
-  #   - name: Configure Meson
-  #     run: meson setup ${{github.workspace}}/build 
-
-  #   - name: Build
-  #     # Build your program with the given configuration
-  #     run: meson compile -C ${{github.workspace}}/build
+  build-ubuntu:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        submodules: recursive
+    - name: Install various apt dependencies
+      run: sudo apt-get install build-essential cmake meson ninja-build nlohmann-json3-dev pkg-config libssl-dev libsdl2-dev
+    - name: Configure Meson
+      run: meson setup ${{github.workspace}}/build 
+    - name: Build
+      run: meson compile -C ${{github.workspace}}/build
   build-macos:
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v3
         with:
           submodules: recursive
-      - run: brew install gcc meson
-      - run: brew install nlohmann-json sdl2
-      - run: meson setup ${{github.workspace}}/build
+      - name: Install dependencies (brew)
+        run: brew install gcc meson nlohmann-json sdl2 curl
+      - name: Meson setup
+        run: PKG_CONFIG_PATH="/usr/local/opt/curl/lib/pkgconfig" meson setup ${{github.workspace}}/build
         env:
           CC: gcc
       - run: meson compile -C ${{github.workspace}}/build -v

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,7 +35,8 @@ jobs:
         with:
           python-version: '3.x'
       - run: brew install gcc
-      - run: pip install meson ninja
+      - run: brew install meson
+      - run: brew install nlohmann-json
       - run: meson setup ${{github.workspace}}/build
         env:
           CC: gcc

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,24 +8,36 @@ on:
     - cron: '0 0 * * 6'
 
 jobs:
-  build:
-    # The CMake configure and build commands are platform agnostic and should work equally
-    # well on Windows or Mac.  You can convert this to a matrix build if you need
-    # cross-platform coverage.
-    # See: https://docs.github.com/en/free-pro-team@latest/actions/learn-github-actions/managing-complex-workflows#using-a-build-matrix
-    runs-on: ubuntu-latest
+  # build-ubuntu:
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #   - uses: actions/checkout@v3
+  #     with:
+  #       submodules: recursive
 
+  #   - name: Install various apt dependencies
+  #     run: sudo apt-get install build-essential cmake meson ninja-build nlohmann-json3-dev pkg-config libssl-dev libsdl2-dev
+
+  #   - name: Configure Meson
+  #     run: meson setup ${{github.workspace}}/build 
+
+  #   - name: Build
+  #     # Build your program with the given configuration
+  #     run: meson compile -C ${{github.workspace}}/build
+  build-macos:
+    runs-on: macos-latest
     steps:
-    - uses: actions/checkout@v3
-      with:
-        submodules: recursive
+      - uses: actions/checkout@v3
+        with:
+          submodules: recursive
 
-    - name: Install various apt dependencies
-      run: sudo apt-get install build-essential cmake meson ninja-build nlohmann-json3-dev pkg-config libssl-dev libsdl2-dev
-
-    - name: Configure Meson
-      run: meson setup ${{github.workspace}}/build 
-
-    - name: Build
-      # Build your program with the given configuration
-      run: meson compile -C ${{github.workspace}}/build
+      - uses: actions/setup-python@v1
+        with:
+          python-version: '3.x'
+      - run: brew install gcc
+      - run: pip install meson ninja
+      - run: meson setup ${{github.workspace}}/build
+        env:
+          CC: gcc
+      - run: meson compile -C ${{github.workspace}}/build -v
+      

--- a/meson.build
+++ b/meson.build
@@ -15,19 +15,31 @@ ftxui_component_dep = dependency('ftxui-component')
 curl_dep = dependency('curl')
 
 
+brew_prefix='/opt/homebrew/include'
+brew = find_program('brew', required: false)
+if brew.found()
+  cmd_brew_prefix = run_command('brew', '--prefix', check:false)
+  if cmd_brew_prefix.returncode() == 0
+    brew_prefix = cmd_brew_prefix.stdout().strip()
+  endif
+endif
+
+
 cmake = import('cmake')
 cmake_options = cmake.subproject_options()
 cmake_options.append_compile_args('c',
   '-DLV_CONF_INCLUDE_SIMPLE',
   '-DLV_LVGL_H_INCLUDE_SIMPLE',
   '-DLV_CONF_PATH=' + meson.current_build_dir() +'/../src/lv_conf.h',
-  '-I'+meson.current_build_dir()+'/../src', '-I'+meson.current_build_dir()+'/../subprojects/lvgl'
+  '-I'+meson.current_build_dir()+'/../src', '-I'+meson.current_build_dir()+'/../subprojects/lvgl',
+  '-I/'+brew_prefix+'/include'
   )
 cmake_options.append_compile_args('cpp',
   '-DLV_CONF_INCLUDE_SIMPLE',
   '-DLV_LVGL_H_INCLUDE_SIMPLE',
   '-DLV_CONF_PATH=' + meson.current_build_dir() +'/../src/lv_conf.h',
-  '-I'+meson.current_build_dir()+'/../src', '-I'+meson.current_build_dir()+'/../subprojects/lvgl'
+  '-I'+meson.current_build_dir()+'/../src', '-I'+meson.current_build_dir()+'/../subprojects/lvgl',
+  '-I/'+brew_prefix+'/include'
   )
 
 lvgl_proj = cmake.subproject('lvgl', options: cmake_options)

--- a/src/HAEntity.hpp
+++ b/src/HAEntity.hpp
@@ -4,6 +4,8 @@
 
 #include <nlohmann/json.hpp>
 #include <iostream>
+#include <string>
+#include <sstream>
 
 using std::map;
 using std::string;

--- a/src/WSConn.cpp
+++ b/src/WSConn.cpp
@@ -19,7 +19,7 @@ WSConn::WSConn(std::string url)
 std::string WSConn::recv(void)
 {
   size_t recv;
-  struct curl_ws_frame* meta;
+  const struct curl_ws_frame* meta;
   struct pollfd pfd;
 
   char buffer[8192];
@@ -27,7 +27,8 @@ std::string WSConn::recv(void)
   std::string result;
 
   pfd.events = POLLIN;
-  /* cerr<< */ curl_easy_getinfo(wshandle, CURLINFO_ACTIVESOCKET, &pfd.fd) /* <<endl */;
+  /* cerr<< */ curl_easy_getinfo(wshandle, CURLINFO_ACTIVESOCKET,
+                                 &pfd.fd) /* <<endl */;
 
   CURLcode ret;
 
@@ -52,7 +53,9 @@ std::string WSConn::recv(void)
       poll(&pfd, 1, 1000);
     }
     else {
-      throw std::runtime_error("got error from curl_ws_recv: " + std::string(curl_easy_strerror(ret))); // FIXME: does not hold wshandlelock, might even print the wrong error in theory
+      throw std::runtime_error(
+        "got error from curl_ws_recv: " + std::string(curl_easy_strerror(ret))); // FIXME: does not hold wshandlelock, might even print the
+                                                                                 // wrong error in theory
     }
   }
   // cerr<<"ret="<<ret<<endl;

--- a/subprojects/curl.wrap
+++ b/subprojects/curl.wrap
@@ -1,9 +1,9 @@
 [wrap-file]
-directory = curl-8.0.1
+directory = curl-8.5.0
 
-source_url = https://curl.se/download/curl-8.0.1.tar.bz2
-source_filename = curl-8.0.1.tar.bz2
-source_hash = 9b6b1e96b748d04b968786b6bdf407aa5c75ab53a3d37c1c8c81cdb736555ccf
+source_url = https://curl.se/download/curl-8.5.0.tar.bz2
+source_filename = curl-8.5.0.tar.bz2
+source_hash = ce4b6a6655431147624aaf582632a36fe1ade262d5fab385c60f78942dd8d87b
 patch_directory = curl
 
 [provide]


### PR DESCRIPTION
On macos, we can do `brew install curl` and get curl 8.5 (at the moment). We then tell it via env variable where to find that pkgconfig. This makes it build on macos.

Because we had curl 8.0.1 as our subproject, it means we had a code issue (something in curl changed, it seems). So, we've also upgraded our subproject in the repository to 8.5, making code work on both macos and ubuntu builds.