### PR TITLE
Retrieve long token in register.sh

### DIFF
--- a/scripts/docker/register.sh
+++ b/scripts/docker/register.sh
@@ -1,7 +1,5 @@
 #!/bin/sh
 
-
-
 CHECK_COUNT=0
 curl 'http://localhost:8123/'
 while [ $? -ne 0 ]
@@ -51,6 +49,6 @@ then
     echo HA_WS_URL=ws://localhost:8123/api/websocket HA_API_TOKEN="`cat longtoken.txt`"
     rm longtoken.txt
 else
-    echo "WARNING - Providing SHORT lived token"
+    echo "WARNING - could not find build/client-cli. Providing SHORT lived token"
     echo HA_WS_URL=ws://localhost:8123/api/websocket HA_API_TOKEN="${TOKEN}"
 fi

--- a/scripts/docker/register.sh
+++ b/scripts/docker/register.sh
@@ -23,7 +23,7 @@ curl 'http://localhost:8123/api/onboarding/users' -X POST  --data-raw '{"client_
 MSG=`jq -r '.message' auth_code.json`
 if [ "${MSG}" != "User step already done" ]; then
     CODE=`jq -r '.auth_code' auth_code.json`
-    curl 'http://localhost:8123/auth/token' -X POST --trace trace.txt -F "grant_type=authorization_code" -F "code=${CODE}" -F "client_id=http://localhost:8123/" > token.json
+    curl 'http://localhost:8123/auth/token' -X POST -F "grant_type=authorization_code" -F "code=${CODE}" -F "client_id=http://localhost:8123/" > token.json
     TOKEN=`jq -r '.access_token' token.json`
 
     # To complete setup, you have to set some other stuff. For whatever reason (might be because demo mode) these requests are empty in our capture.
@@ -32,8 +32,8 @@ if [ "${MSG}" != "User step already done" ]; then
     curl 'http://localhost:8123/api/onboarding/integration'  -X POST -H "authorization: Bearer ${TOKEN}" -d '{"client_id":"http://localhost:8123/","redirect_uri":"http://localhost:8123/?auth_callback=1"}'
 fi
 
-# rm auth_code.json
-# rm token.json
+rm auth_code.json
+rm token.json
 
 echo
 echo

--- a/scripts/docker/register.sh
+++ b/scripts/docker/register.sh
@@ -1,9 +1,5 @@
 #!/bin/sh
 
-# We need to compile our code for the ha-long-token
-cd ../../
-meson setup build
-meson compile -C build
 
 
 CHECK_COUNT=0
@@ -39,6 +35,14 @@ fi
 
 rm auth_code.json
 rm token.json
+
+if [ ! -x "build/client-cli" ]
+then
+    echo "Compiling meson to get client-cli"
+    cd ../../
+    meson setup build
+    meson compile -C build
+fi
 
 HA_WS_URL=ws://localhost:8123/api/websocket HA_API_TOKEN="${TOKEN}" LD_LIBRARY_PATH=build/subprojects/curl-8.5.0/build/lib/.libs/ build/client-cli ha-get-token 1>longtoken.txt
 

--- a/scripts/docker/register.sh
+++ b/scripts/docker/register.sh
@@ -47,9 +47,10 @@ fi
 if [ -x "build/client-cli" ]
 then
     HA_WS_URL=ws://localhost:8123/api/websocket HA_API_TOKEN="${TOKEN}" LD_LIBRARY_PATH=build/subprojects/curl-8.5.0/build/lib/.libs/ build/client-cli ha-get-token 1>longtoken.txt
+    echo "Providing long lived token"
     echo HA_WS_URL=ws://localhost:8123/api/websocket HA_API_TOKEN="`cat longtoken.txt`"
     rm longtoken.txt
 else
-    echo "WARNING - compile of client-cli failed, providing SHORT LIVED TOKEN"
+    echo "WARNING - Providing SHORT lived token"
     echo HA_WS_URL=ws://localhost:8123/api/websocket HA_API_TOKEN="${TOKEN}"
 fi

--- a/scripts/docker/register.sh
+++ b/scripts/docker/register.sh
@@ -44,7 +44,12 @@ then
     meson compile -C build
 fi
 
-HA_WS_URL=ws://localhost:8123/api/websocket HA_API_TOKEN="${TOKEN}" LD_LIBRARY_PATH=build/subprojects/curl-8.5.0/build/lib/.libs/ build/client-cli ha-get-token 1>longtoken.txt
-
-echo HA_WS_URL=ws://localhost:8123/api/websocket HA_API_TOKEN="`cat longtoken.txt`"
-rm longtoken.txt
+if [ -x "build/client-cli" ]
+then
+    HA_WS_URL=ws://localhost:8123/api/websocket HA_API_TOKEN="${TOKEN}" LD_LIBRARY_PATH=build/subprojects/curl-8.5.0/build/lib/.libs/ build/client-cli ha-get-token 1>longtoken.txt
+    echo HA_WS_URL=ws://localhost:8123/api/websocket HA_API_TOKEN="`cat longtoken.txt`"
+    rm longtoken.txt
+else
+    echo "WARNING - compile of client-cli failed, providing SHORT LIVED TOKEN"
+    echo HA_WS_URL=ws://localhost:8123/api/websocket HA_API_TOKEN="${TOKEN}"
+fi

--- a/scripts/docker/register.sh
+++ b/scripts/docker/register.sh
@@ -34,14 +34,6 @@ fi
 rm auth_code.json
 rm token.json
 
-if [ ! -x "build/client-cli" ]
-then
-    echo "Compiling meson to get client-cli"
-    cd ../../
-    meson setup build
-    meson compile -C build
-fi
-
 if [ -x "build/client-cli" ]
 then
     HA_WS_URL=ws://localhost:8123/api/websocket HA_API_TOKEN="${TOKEN}" LD_LIBRARY_PATH=build/subprojects/curl-8.5.0/build/lib/.libs/ build/client-cli ha-get-token 1>longtoken.txt

--- a/scripts/docker/register.sh
+++ b/scripts/docker/register.sh
@@ -1,5 +1,11 @@
 #!/bin/sh
 
+# We need to compile our code for the ha-long-token
+cd ../../
+meson setup build
+meson compile -C build
+
+
 CHECK_COUNT=0
 curl 'http://localhost:8123/'
 while [ $? -ne 0 ]
@@ -19,22 +25,22 @@ done
 
 
 # Create voorkant user
-curl 'http://localhost:8123/api/onboarding/users' -X POST  --data-raw '{"client_id":"http://localhost:8123/","name":"voorkant","username":"voorkant","password":"v00rk4nt","language":"en-GB"}' > auth_code.json
+curl 'http://localhost:8123/api/onboarding/users' -s -X POST  --data-raw '{"client_id":"http://localhost:8123/","name":"voorkant","username":"voorkant","password":"v00rk4nt","language":"en-GB"}' > auth_code.json
 MSG=`jq -r '.message' auth_code.json`
 if [ "${MSG}" != "User step already done" ]; then
     CODE=`jq -r '.auth_code' auth_code.json`
-    curl 'http://localhost:8123/auth/token' -X POST -F "grant_type=authorization_code" -F "code=${CODE}" -F "client_id=http://localhost:8123/" > token.json
+    curl 'http://localhost:8123/auth/token' -s -X POST -F "grant_type=authorization_code" -F "code=${CODE}" -F "client_id=http://localhost:8123/" > token.json
     TOKEN=`jq -r '.access_token' token.json`
-
     # To complete setup, you have to set some other stuff. For whatever reason (might be because demo mode) these requests are empty in our capture.
-    curl 'http://localhost:8123/api/onboarding/core_config' -X POST -H "authorization: Bearer ${TOKEN}"
-    curl 'http://localhost:8123/api/onboarding/analytics' -X POST -H "authorization: Bearer ${TOKEN}"
-    curl 'http://localhost:8123/api/onboarding/integration'  -X POST -H "authorization: Bearer ${TOKEN}" -d '{"client_id":"http://localhost:8123/","redirect_uri":"http://localhost:8123/?auth_callback=1"}'
+    curl 'http://localhost:8123/api/onboarding/core_config' -s -X POST -H "authorization: Bearer ${TOKEN}" > /dev/null
+    curl 'http://localhost:8123/api/onboarding/analytics' -s -X POST -H "authorization: Bearer ${TOKEN}" > /dev/null
+    curl 'http://localhost:8123/api/onboarding/integration'  -s -X POST -H "authorization: Bearer ${TOKEN}" -d '{"client_id":"http://localhost:8123/","redirect_uri":"http://localhost:8123/?auth_callback=1"}' > /dev/null
 fi
 
 rm auth_code.json
 rm token.json
 
-echo
-echo
-echo HA_WS_URL=ws://localhost:8123/api/websocket HA_API_TOKEN="${TOKEN}"
+HA_WS_URL=ws://localhost:8123/api/websocket HA_API_TOKEN="${TOKEN}" LD_LIBRARY_PATH=build/subprojects/curl-8.5.0/build/lib/.libs/ build/client-cli ha-get-token 1>longtoken.txt
+
+echo HA_WS_URL=ws://localhost:8123/api/websocket HA_API_TOKEN="`cat longtoken.txt`"
+rm longtoken.txt

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -12,7 +12,6 @@
 #include "HAEntity.hpp"
 
 using std::cerr;
-using std::cout;
 using std::endl;
 using std::string;
 
@@ -33,8 +32,7 @@ int main(int argc, char* argv[])
 {
   HABackend backend;
   if (backend.Connect(GetEnv("HA_WS_URL"), GetEnv("HA_API_TOKEN"))) {
-    cout << "Connect succesful. Starting." << endl;
-
+    cerr << "Connect succesful. Starting." << endl;
     std::thread ui(uithread, std::ref(backend), argc, argv);
     ui.join();
   }


### PR DESCRIPTION
This gives us a long lived token out of register.sh, which is easier to work with and allows us to developer for longer than one hour. Yes, we're slow like that :smile: 

We currently still use a trick to redirect cerr to somewhere else, to only capture the token. This likely will break as we forget about this, and realistically tihs is only needed because `main()` does the `connect()` and `start()`. It would be better if the uithread function creates and starts the backend. The UI might dictate where the configuration of the URL is stored, and thus should provide that to the backend. (for cli, we might do environment vars, for lvgl we might have some config file or UI setting?)