### PR TITLE
client-cli dump-command: accept optional extra data

### DIFF
--- a/src/Backend.cpp
+++ b/src/Backend.cpp
@@ -71,9 +71,10 @@ string HABackend::CreateLongToken(string name)
   return "NO_TOKEN";
 }
 
-json HABackend::DoCommand(const string& command)
+json HABackend::DoCommand(const string& command, const json& data)
 {
   json request;
+  request = data;
   request["type"] = command;
   wc->send(request);
   auto response = wc->recv();

--- a/src/Backend.hpp
+++ b/src/Backend.hpp
@@ -23,7 +23,7 @@ public:
   HABackend();
   bool Connect(string url, string token);
   bool Start();
-  json DoCommand(const std::string& command);
+  json DoCommand(const std::string& command, const json& data);
   string CreateLongToken(string name);
   std::shared_ptr<HAEntity> GetEntityByName(const std::string& name);
   map<string, std::shared_ptr<HAEntity>> GetEntities();

--- a/src/front-cli.cpp
+++ b/src/front-cli.cpp
@@ -33,8 +33,13 @@ void uithread(HABackend& backend, int argc, char* argv[])
   argparse::ArgumentParser list_entities_command("list-entities");
   program.add_subparser(list_entities_command);
 
+  /* usage example for dump-command with data:
+   * build/client-cli dump-command call_service '{"domain":"light","service":"toggle","target":{"entity_id":"light.bed_light"}}'
+   */
   argparse::ArgumentParser dump_command("dump-command");
   dump_command.add_argument("command").help("the command to execute");
+  dump_command.add_argument("data").help("optional data to pass with the command").default_value("{}");
+
   program.add_subparser(dump_command);
 
   try {
@@ -68,7 +73,8 @@ void uithread(HABackend& backend, int argc, char* argv[])
     }
   }
   else if (program.is_subcommand_used(dump_command)) {
-    json res = backend.DoCommand(dump_command.get<string>("command"));
+    json data = json::parse(dump_command.get<string>("data"));
+    json res = backend.DoCommand(dump_command.get<string>("command"), data);
     cout << res.dump(2) << endl;
   }
   else {


### PR DESCRIPTION
example usage:

$ build/client-cli dump-command call_service '{"domain":"light","service":"toggle","target":{"entity_id":"light.bed_light"}}'