### PR TITLE
Uicomponents

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -65,7 +65,7 @@ executable('client-ftxui',
        )
 
 executable('client-lvgl-sdl',
-           ['src/main.cpp', 'src/Backend.cpp', 'src/HAEntity.cpp', 'src/WSConn.cpp', 'src/front-lvgl.cpp', 'src/lv_conf.h', 'src/generated/domains.hpp'],
+           ['src/main.cpp', 'src/UIComponents.hpp', 'src/Backend.cpp', 'src/HAEntity.cpp', 'src/WSConn.cpp', 'src/front-lvgl.cpp', 'src/lv_conf.h', 'src/generated/domains.hpp'],
           install : true,
       dependencies : [json_dep, thread_dep, curl_dep, lvgl_dep, lvgl_drivers_dep, sdl2_dep],
       include_directories: incdir,

--- a/meson.build
+++ b/meson.build
@@ -65,7 +65,7 @@ executable('client-ftxui',
        )
 
 executable('client-lvgl-sdl',
-           ['src/main.cpp', 'src/UIComponents.hpp', 'src/Backend.cpp', 'src/HAEntity.cpp', 'src/WSConn.cpp', 'src/front-lvgl.cpp', 'src/lv_conf.h', 'src/generated/domains.hpp'],
+           ['src/main.cpp', 'src/Backend.cpp', 'src/HAEntity.cpp', 'src/WSConn.cpp', 'src/UIComponents.cpp', 'src/front-lvgl.cpp', 'src/lv_conf.h', 'src/generated/domains.hpp'],
           install : true,
       dependencies : [json_dep, thread_dep, curl_dep, lvgl_dep, lvgl_drivers_dep, sdl2_dep],
       include_directories: incdir,

--- a/meson.build
+++ b/meson.build
@@ -59,7 +59,7 @@ executable('client-ftxui',
      )
 
  executable('client-cli',
-            ['src/main.cpp', 'src/Backend.cpp', 'src/HAEntity.cpp','src/WSConn.cpp','src/front-cli.cpp', 'src/generated/domains.hpp'],
+            ['src/main.cpp', 'src/Backend.cpp', 'src/Observer.hpp', 'src/HAEntity.cpp','src/WSConn.cpp','src/front-cli.cpp', 'src/generated/domains.hpp'],
             install : true,
        dependencies : [json_dep, thread_dep, curl_dep]
        )

--- a/meson.build
+++ b/meson.build
@@ -64,7 +64,7 @@ executable('client-ftxui',
        dependencies : [json_dep, thread_dep, curl_dep]
        )
 
-executable('client-lvgl-sdl',
+executable('client-lvgl',
            ['src/main.cpp', 'src/Backend.cpp', 'src/HAEntity.cpp', 'src/WSConn.cpp', 'src/UIComponents.cpp', 'src/front-lvgl.cpp', 'src/lv_conf.h', 'src/generated/domains.hpp'],
           install : true,
       dependencies : [json_dep, thread_dep, curl_dep, lvgl_dep, lvgl_drivers_dep, sdl2_dep],

--- a/src/Backend.cpp
+++ b/src/Backend.cpp
@@ -153,7 +153,9 @@ void HABackend::threadrunner()
         auto new_state = evd["new_state"];
 
         if (event_type == "state_changed") {
-          entities[entity_id]->update(new_state);
+          auto ent = entities[entity_id];
+          ent->update(new_state);
+          std::cerr << "DID UPDATE() ON " << ent->name << std::endl;
           whatchanged.push_back(entity_id);
         }
         else {

--- a/src/Backend.cpp
+++ b/src/Backend.cpp
@@ -177,6 +177,17 @@ map<string, std::shared_ptr<HAEntity>> HABackend::GetEntities()
   return entities;
 }
 
+std::vector<std::shared_ptr<HAEntity>> HABackend::GetEntitiesByDomain(const std::string& domain)
+{
+  std::vector<std::shared_ptr<HAEntity>> ret;
+  for (auto& [id, entity] : entities) {
+    if (entity->domain == domain) {
+      ret.push_back(entity);
+    }
+  }
+  return ret;
+}
+
 std::shared_ptr<HAEntity> HABackend::GetEntityByName(const std::string& name)
 {
   std::scoped_lock lk(entitieslock);

--- a/src/Backend.cpp
+++ b/src/Backend.cpp
@@ -103,7 +103,6 @@ void HABackend::threadrunner()
     std::scoped_lock lk(domainslock);
     domains[domain] = std::make_shared<HADomain>(domain, services);
   }
-  cerr << "We have " << domains.size() << "domains " << endl;
 
   json subscribe;
   subscribe["type"] = "subscribe_events";
@@ -163,7 +162,7 @@ void HABackend::threadrunner()
       }
       else {
         cerr << "Received message we don't expect: " << j["type"] << endl;
-        // not a message we were expecting
+        cerr << j.dump(2) << endl;
         continue;
       }
     }

--- a/src/Backend.cpp
+++ b/src/Backend.cpp
@@ -118,7 +118,6 @@ void HABackend::threadrunner()
     // cout<<msg<<endl;
     json j = json::parse(msg);
 
-    std::vector<std::string> whatchanged;
     {
 
       if (j["id"] == getstates["id"]) {
@@ -136,7 +135,6 @@ void HABackend::threadrunner()
 
           // FIXME: we should check if the domain actually exists before just calling for it.
           entities[entity_id] = std::make_shared<HAEntity>(evd, domains[domain], this); // FIXME: we share `this` entirely unprotected from threading mistakes here
-          whatchanged.push_back(entity_id);
         }
         std::unique_lock<std::mutex> lck(load_lock);
         loaded = true;
@@ -155,8 +153,6 @@ void HABackend::threadrunner()
         if (event_type == "state_changed") {
           auto ent = entities[entity_id];
           ent->update(new_state);
-          std::cerr << "DID UPDATE() ON " << ent->name << std::endl;
-          whatchanged.push_back(entity_id);
         }
         else {
           cerr << "Event type received that we didn't expect: " << event_type << endl;
@@ -168,8 +164,6 @@ void HABackend::threadrunner()
         continue;
       }
     }
-
-    uithread_refresh(this, whatchanged);
   }
 }
 

--- a/src/Backend.hpp
+++ b/src/Backend.hpp
@@ -26,6 +26,7 @@ public:
   json DoCommand(const std::string& command, const json& data);
   string CreateLongToken(string name);
   std::shared_ptr<HAEntity> GetEntityByName(const std::string& name);
+  std::vector<std::shared_ptr<HAEntity>> GetEntitiesByDomain(const std::string& domain);
   map<string, std::shared_ptr<HAEntity>> GetEntities();
   void WSConnSend(json& msg);
 

--- a/src/HAEntity.cpp
+++ b/src/HAEntity.cpp
@@ -84,7 +84,7 @@ void HAEntity::detach(IObserver* observer)
 
 void HAEntity::notify()
 {
-  std::cerr << "Performing notify() for " << name << std::endl;
+  std::cerr << "Performing notify() for " << name << " on " << uientities.size() << " uientities" << std::endl;
   for (auto uientity : uientities) {
     uientity->uiupdate();
   }

--- a/src/HAEntity.cpp
+++ b/src/HAEntity.cpp
@@ -84,8 +84,7 @@ void HAEntity::detach(IObserver* observer)
 
 void HAEntity::notify()
 {
-  std::cerr << "Performing notify() for " << name << " on " << uientities.size() << " uientities" << std::endl;
-  for (auto uientity : uientities) {
+  for (const auto& uientity : uientities) {
     uientity->uiupdate();
   }
 }
@@ -99,7 +98,7 @@ HADomain::HADomain(std::string _name, json _state)
 {
   state = _state;
   name = _name;
-  for (auto& [service, info] : state.items()) {
+  for (const auto& [service, info] : state.items()) {
     auto haservice = std::make_shared<HAService>(info);
     services.push_back(haservice);
   }

--- a/src/HAEntity.cpp
+++ b/src/HAEntity.cpp
@@ -75,11 +75,11 @@ std::string HAEntity::getNameFromState(void)
 
 void HAEntity::attach(IObserver* observer)
 {
-  uientities.push_back(observer);
+  uientities.insert(observer);
 }
 void HAEntity::detach(IObserver* observer)
 {
-  uientities.remove(observer);
+  uientities.erase(observer);
 }
 
 void HAEntity::notify()

--- a/src/HAEntity.cpp
+++ b/src/HAEntity.cpp
@@ -84,6 +84,7 @@ void HAEntity::detach(IObserver* observer)
 
 void HAEntity::notify()
 {
+  std::cerr << "Performing notify() for " << name << std::endl;
   for (auto uientity : uientities) {
     uientity->uiupdate();
   }

--- a/src/HAEntity.cpp
+++ b/src/HAEntity.cpp
@@ -23,6 +23,7 @@ HAEntity::HAEntity(json _state, std::shared_ptr<HADomain> _hadomain, HABackend* 
 void HAEntity::update(json _state)
 {
   state = _state;
+  notify();
 }
 
 std::vector<std::shared_ptr<HAService>> HAEntity::getServices()
@@ -69,6 +70,22 @@ std::string HAEntity::getNameFromState(void)
   }
   else {
     return "UNKNOWN_" + state["entity_id"].get<string>();
+  }
+}
+
+void HAEntity::attach(IObserver* observer)
+{
+  uientities.push_back(observer);
+}
+void HAEntity::detach(IObserver* observer)
+{
+  uientities.remove(observer);
+}
+
+void HAEntity::notify()
+{
+  for (auto uientity : uientities) {
+    uientity->uiupdate();
   }
 }
 

--- a/src/HAEntity.hpp
+++ b/src/HAEntity.hpp
@@ -6,7 +6,9 @@
 #include <iostream>
 #include <string>
 #include <sstream>
+#include <list>
 #include "ext/magic_enum/include/magic_enum/magic_enum_all.hpp"
+#include "Observer.hpp"
 
 using std::map;
 using std::string;
@@ -46,13 +48,14 @@ private:
 
 class HABackend; // so we can have a pointer to it
 
-class HAEntity
+class HAEntity : public ISubject
 {
 public:
   string name;
   string domain;
   string id;
 
+  HAEntity(){}; // FIXME - why do we need this for ISubject?
   // HAEntity(json _state);
   HAEntity(json _state, std::shared_ptr<HADomain> _hadomain, HABackend* _backend);
   ~HAEntity(){};
@@ -95,10 +98,15 @@ public:
 
   void WSConnSend(json& msg); // FIXME: this is a hack because HADomains::Light cannot get to the backend easily
 
+  void attach(IObserver* uientity) override;
+  void detach(IObserver* uientity) override;
+  void notify() override;
+
 protected:
   HABackend* backend;
 
 private:
+  std::list<IObserver*> uientities; // FIXME - should be a vector, the Detach() needs work for that.
   std::shared_ptr<HADomain> hadomain;
   std::string getDomainFromState();
   std::string getNameFromState();

--- a/src/HAEntity.hpp
+++ b/src/HAEntity.hpp
@@ -55,7 +55,6 @@ public:
   string domain;
   string id;
 
-  HAEntity(){}; // FIXME - why do we need this for ISubject?
   // HAEntity(json _state);
   HAEntity(json _state, std::shared_ptr<HADomain> _hadomain, HABackend* _backend);
   ~HAEntity(){};

--- a/src/HAEntity.hpp
+++ b/src/HAEntity.hpp
@@ -6,7 +6,7 @@
 #include <iostream>
 #include <string>
 #include <sstream>
-#include <list>
+#include <set>
 #include "ext/magic_enum/include/magic_enum/magic_enum_all.hpp"
 #include "Observer.hpp"
 
@@ -105,7 +105,7 @@ protected:
   HABackend* backend;
 
 private:
-  std::list<IObserver*> uientities; // FIXME - should be a vector, the Detach() needs work for that.
+  std::set<IObserver*> uientities; // FIXME - should be a vector, the Detach() needs work for that.
   std::shared_ptr<HADomain> hadomain;
   std::string getDomainFromState();
   std::string getNameFromState();

--- a/src/HAEntity.hpp
+++ b/src/HAEntity.hpp
@@ -105,7 +105,7 @@ protected:
   HABackend* backend;
 
 private:
-  std::set<IObserver*> uientities; // FIXME - should be a vector, the Detach() needs work for that.
+  std::set<IObserver*> uientities;
   std::shared_ptr<HADomain> hadomain;
   std::string getDomainFromState();
   std::string getNameFromState();

--- a/src/Observer.hpp
+++ b/src/Observer.hpp
@@ -2,8 +2,6 @@
 #ifndef OBSERVER_HPP
 #define OBSERVER_HPP
 
-#include "HAEntity.hpp"
-
 /*
 Generally, our UIEntities are observers, and our HAentities are subjects.
 We have this specific "interface" inspired by https://refactoring.guru/design-patterns/observer/cpp/example because we don't want

--- a/src/Observer.hpp
+++ b/src/Observer.hpp
@@ -1,0 +1,26 @@
+
+#ifndef OBSERVER_HPP
+#define OBSERVER_HPP
+
+/*
+Generally, our UIEntities are observers, and our HAentities are subjects.
+We have this specific "interface" inspired by https://refactoring.guru/design-patterns/observer/cpp/example because we don't want
+HAEntity to have a direct link to UIEntity. If we do that, then HAEntity would know about lvgl.h which it shouldn't.
+*/
+class IObserver
+{
+public:
+  virtual ~IObserver(){};
+  virtual void uiupdate();
+};
+
+class ISubject
+{
+public:
+  virtual ~ISubject(){};
+  virtual void attach(IObserver* observer);
+  virtual void detach(IObserver* observer);
+  virtual void notify();
+};
+
+#endif

--- a/src/Observer.hpp
+++ b/src/Observer.hpp
@@ -2,6 +2,8 @@
 #ifndef OBSERVER_HPP
 #define OBSERVER_HPP
 
+#include "HAEntity.hpp"
+
 /*
 Generally, our UIEntities are observers, and our HAentities are subjects.
 We have this specific "interface" inspired by https://refactoring.guru/design-patterns/observer/cpp/example because we don't want

--- a/src/Observer.hpp
+++ b/src/Observer.hpp
@@ -10,17 +10,15 @@ HAEntity to have a direct link to UIEntity. If we do that, then HAEntity would k
 class IObserver
 {
 public:
-  virtual ~IObserver(){};
-  virtual void uiupdate();
+  virtual void uiupdate() = 0;
 };
 
 class ISubject
 {
 public:
-  virtual ~ISubject(){};
-  virtual void attach(IObserver* observer);
-  virtual void detach(IObserver* observer);
-  virtual void notify();
+  virtual void attach(IObserver* observer) = 0;
+  virtual void detach(IObserver* observer) = 0;
+  virtual void notify() = 0;
 };
 
 #endif

--- a/src/UIComponents.cpp
+++ b/src/UIComponents.cpp
@@ -20,7 +20,7 @@ UIButton::UIButton(std::shared_ptr<HAEntity> _entity, lv_obj_t* _parent) :
   lv_obj_set_size(btn, 240, 50);
   lv_obj_center(btn);
   lv_obj_add_flag(btn, LV_OBJ_FLAG_CHECKABLE);
-  lv_obj_add_event_cb(btn, btn_press_cb, LV_EVENT_ALL, reinterpret_cast<void*>(&entity)); /*Assign a callback to the button*/
+  lv_obj_add_event_cb(btn, UIButton::btn_press_cb, LV_EVENT_ALL, reinterpret_cast<void*>(&entity)); /*Assign a callback to the button*/
 
   lv_obj_t* label = lv_label_create(btn); /*Add a label to the button*/
   lv_label_set_text(label, _entity->name.c_str()); /*Set the labels text*/
@@ -39,6 +39,17 @@ void UIButton::uiupdate()
   }
 };
 
+void UIButton::btn_press_cb(lv_event_t* e)
+{
+  lv_event_code_t code = lv_event_get_code(e);
+
+  std::shared_ptr<HAEntity> ent = *reinterpret_cast<std::shared_ptr<HAEntity>*>(e->user_data);
+  if (code == LV_EVENT_VALUE_CHANGED) {
+    HADomains::Light light(ent);
+    light.toggle({});
+  }
+};
+
 UISwitch::UISwitch(std::shared_ptr<HAEntity> _entity, lv_obj_t* _parent) :
   UIEntity(_entity, _parent)
 {
@@ -48,7 +59,7 @@ UISwitch::UISwitch(std::shared_ptr<HAEntity> _entity, lv_obj_t* _parent) :
   lv_obj_center(switchcontainer);
 
   sw = lv_switch_create(switchcontainer); /*Add a button the current screen*/
-  lv_obj_add_event_cb(sw, btn_press_cb, LV_EVENT_ALL, reinterpret_cast<void*>(&entity)); /*Assign a callback to the button*/
+  lv_obj_add_event_cb(sw, UISwitch::sw_toggle_cb, LV_EVENT_ALL, reinterpret_cast<void*>(&entity)); /*Assign a callback to the button*/
   lv_obj_add_flag(sw, LV_OBJ_FLAG_EVENT_BUBBLE);
   lv_obj_set_align(sw, LV_ALIGN_RIGHT_MID);
 
@@ -65,5 +76,16 @@ void UISwitch::uiupdate()
   }
   else {
     lv_obj_clear_state(sw, LV_STATE_CHECKED);
+  }
+};
+
+void UISwitch::sw_toggle_cb(lv_event_t* e)
+{
+  lv_event_code_t code = lv_event_get_code(e);
+
+  std::shared_ptr<HAEntity> ent = *reinterpret_cast<std::shared_ptr<HAEntity>*>(e->user_data);
+  if (code == LV_EVENT_VALUE_CHANGED) {
+    HADomains::Light light(ent);
+    light.toggle({});
   }
 };

--- a/src/UIComponents.cpp
+++ b/src/UIComponents.cpp
@@ -1,0 +1,69 @@
+#include "UIComponents.hpp"
+
+UIEntity::~UIEntity()
+{
+  entity->detach((IObserver*)this);
+};
+
+UIEntity::UIEntity(std::shared_ptr<HAEntity> _entity, lv_obj_t* _parent)
+{
+  parentContainer = _parent;
+  entity = _entity;
+  entity->attach((IObserver*)this);
+};
+
+UIButton::UIButton(std::shared_ptr<HAEntity> _entity, lv_obj_t* _parent) :
+  UIEntity(_entity, _parent)
+{
+  // START BUTTON EXAMPLE
+  btn = lv_btn_create(_parent); /*Add a button the current screen*/
+  lv_obj_set_size(btn, 240, 50);
+  lv_obj_center(btn);
+  lv_obj_add_flag(btn, LV_OBJ_FLAG_CHECKABLE);
+  lv_obj_add_event_cb(btn, btn_press_cb, LV_EVENT_ALL, reinterpret_cast<void*>(&entity)); /*Assign a callback to the button*/
+
+  lv_obj_t* label = lv_label_create(btn); /*Add a label to the button*/
+  lv_label_set_text(label, _entity->name.c_str()); /*Set the labels text*/
+  lv_obj_center(label);
+  uiupdate();
+};
+
+void UIButton::uiupdate()
+{
+  auto state = entity->getJsonState();
+  if (state["state"] == "on") {
+    lv_obj_add_state(btn, LV_STATE_CHECKED);
+  }
+  else {
+    lv_obj_clear_state(btn, LV_STATE_CHECKED);
+  }
+};
+
+UISwitch::UISwitch(std::shared_ptr<HAEntity> _entity, lv_obj_t* _parent) :
+  UIEntity(_entity, _parent)
+{
+  // START BUTTON EXAMPLE
+  lv_obj_t* switchcontainer = lv_obj_create(_parent);
+  lv_obj_set_size(switchcontainer, 240, 50);
+  lv_obj_center(switchcontainer);
+
+  sw = lv_switch_create(switchcontainer); /*Add a button the current screen*/
+  lv_obj_add_event_cb(sw, btn_press_cb, LV_EVENT_ALL, reinterpret_cast<void*>(&entity)); /*Assign a callback to the button*/
+  lv_obj_add_flag(sw, LV_OBJ_FLAG_EVENT_BUBBLE);
+  lv_obj_set_align(sw, LV_ALIGN_RIGHT_MID);
+
+  lv_obj_t* label = lv_label_create(switchcontainer); /*Add a label to the button*/
+  lv_label_set_text(label, _entity->name.c_str()); /*Set the labels text*/
+  uiupdate();
+};
+
+void UISwitch::uiupdate()
+{
+  auto state = entity->getJsonState();
+  if (state["state"] == "on") {
+    lv_obj_add_state(sw, LV_STATE_CHECKED);
+  }
+  else {
+    lv_obj_clear_state(sw, LV_STATE_CHECKED);
+  }
+};

--- a/src/UIComponents.hpp
+++ b/src/UIComponents.hpp
@@ -8,25 +8,6 @@
 #include "Observer.hpp"
 #include "generated/domains.hpp"
 
-class UIEntity : public IObserver
-{
-public:
-  ~UIEntity()
-  {
-    entity->detach((IObserver*)this);
-  };
-  UIEntity(std::shared_ptr<HAEntity> _entity, lv_obj_t* _parent)
-  {
-    parentContainer = _parent;
-    entity = _entity;
-    entity->attach((IObserver*)this);
-  }
-
-protected:
-  std::shared_ptr<HAEntity> entity;
-  lv_obj_t* parentContainer;
-};
-
 static void btn_press_cb(lv_event_t* e)
 {
   lv_event_code_t code = lv_event_get_code(e);
@@ -38,35 +19,22 @@ static void btn_press_cb(lv_event_t* e)
   }
 }
 
+class UIEntity : public IObserver
+{
+public:
+  ~UIEntity();
+  UIEntity(std::shared_ptr<HAEntity> _entity, lv_obj_t* _parent);
+
+protected:
+  std::shared_ptr<HAEntity> entity;
+  lv_obj_t* parentContainer;
+};
+
 class UIButton : public UIEntity
 {
 public:
-  UIButton(std::shared_ptr<HAEntity> _entity, lv_obj_t* _parent) :
-    UIEntity(_entity, _parent)
-  {
-    // START BUTTON EXAMPLE
-    btn = lv_btn_create(_parent); /*Add a button the current screen*/
-    lv_obj_set_size(btn, 240, 50);
-    lv_obj_center(btn);
-    lv_obj_add_flag(btn, LV_OBJ_FLAG_CHECKABLE);
-    lv_obj_add_event_cb(btn, btn_press_cb, LV_EVENT_ALL, reinterpret_cast<void*>(&entity)); /*Assign a callback to the button*/
-
-    lv_obj_t* label = lv_label_create(btn); /*Add a label to the button*/
-    lv_label_set_text(label, _entity->name.c_str()); /*Set the labels text*/
-    lv_obj_center(label);
-    uiupdate();
-  }
-
-  void uiupdate() override
-  {
-    auto state = entity->getJsonState();
-    if (state["state"] == "on") {
-      lv_obj_add_state(btn, LV_STATE_CHECKED);
-    }
-    else {
-      lv_obj_clear_state(btn, LV_STATE_CHECKED);
-    }
-  }
+  UIButton(std::shared_ptr<HAEntity> _entity, lv_obj_t* _parent);
+  void uiupdate() override;
 
 private:
   lv_obj_t* btn;
@@ -75,34 +43,9 @@ private:
 class UISwitch : public UIEntity
 {
 public:
-  UISwitch(std::shared_ptr<HAEntity> _entity, lv_obj_t* _parent) :
-    UIEntity(_entity, _parent)
-  {
-    // START BUTTON EXAMPLE
-    lv_obj_t* switchcontainer = lv_obj_create(_parent);
-    lv_obj_set_size(switchcontainer, 240, 50);
-    lv_obj_center(switchcontainer);
+  UISwitch(std::shared_ptr<HAEntity> _entity, lv_obj_t* _parent);
 
-    sw = lv_switch_create(switchcontainer); /*Add a button the current screen*/
-    lv_obj_add_event_cb(sw, btn_press_cb, LV_EVENT_ALL, reinterpret_cast<void*>(&entity)); /*Assign a callback to the button*/
-    lv_obj_add_flag(sw, LV_OBJ_FLAG_EVENT_BUBBLE);
-    lv_obj_set_align(sw, LV_ALIGN_RIGHT_MID);
-
-    lv_obj_t* label = lv_label_create(switchcontainer); /*Add a label to the button*/
-    lv_label_set_text(label, _entity->name.c_str()); /*Set the labels text*/
-    uiupdate();
-  }
-
-  void uiupdate() override
-  {
-    auto state = entity->getJsonState();
-    if (state["state"] == "on") {
-      lv_obj_add_state(sw, LV_STATE_CHECKED);
-    }
-    else {
-      lv_obj_clear_state(sw, LV_STATE_CHECKED);
-    }
-  }
+  void uiupdate() override;
 
 private:
   lv_obj_t* sw;

--- a/src/UIComponents.hpp
+++ b/src/UIComponents.hpp
@@ -3,33 +3,49 @@
 #define UICOMPONENTS_HPP
 
 #include "HAEntity.hpp"
+#include "Backend.hpp"
 #include <lvgl.h>
+#include "generated/domains.hpp"
 
 class UIEntity
 {
 public:
-  UIEntity(HAEntity _entity, lv_obj_t* _parent)
+  UIEntity(std::shared_ptr<HAEntity> _entity, lv_obj_t* _parent)
   {
     parentContainer = _parent;
     entity = _entity;
   }
 
-private:
-  HAEntity entity;
+protected:
+  std::shared_ptr<HAEntity> entity;
   lv_obj_t* parentContainer;
 };
 
 class UISwitch : UIEntity
 {
-  UISwitch(HAEntity _entity, lv_obj_t* _parent) :
+public:
+  UISwitch(std::shared_ptr<HAEntity> _entity, lv_obj_t* _parent) :
     UIEntity(_entity, _parent)
   {
-    lv_obj_t* btn = lv_btn_create(parentContainer);
-    lv_obj_set_size(btn, 100, LV_PCT(100));
+    // START BUTTON EXAMPLE
+    lv_obj_t* btn = lv_btn_create(_parent); /*Add a button the current screen*/
+    lv_obj_set_pos(btn, 10, 10); /*Set its position*/
+    lv_obj_set_size(btn, 240, 50); /*Set its size*/
+    lv_obj_add_event_cb(btn, UISwitch::btn_press_cb, LV_EVENT_ALL, NULL); /*Assign a callback to the button*/
 
-    lv_obj_t* label = lv_label_create(btn);
-    lv_label_set_text_fmt(label, "On/Off");
+    lv_obj_t* label = lv_label_create(btn); /*Add a label to the button*/
+    lv_label_set_text(label, _entity->name.c_str()); /*Set the labels text*/
     lv_obj_center(label);
+  }
+
+private:
+  static void btn_press_cb(lv_event_t* e)
+  {
+    lv_event_code_t code = lv_event_get_code(e);
+    if (code == LV_EVENT_CLICKED) {
+      HADomains::Light light(entity);
+      light.toggle({});
+    }
   }
 };
 

--- a/src/UIComponents.hpp
+++ b/src/UIComponents.hpp
@@ -55,7 +55,7 @@ public:
     lv_obj_t* label = lv_label_create(btn); /*Add a label to the button*/
     lv_label_set_text(label, _entity->name.c_str()); /*Set the labels text*/
     lv_obj_center(label);
-    std::cerr << "CREATED button FOR " << entity->name << std::endl;
+    uiupdate();
   }
 
   void uiupdate() override
@@ -94,8 +94,7 @@ public:
 
     lv_obj_t* label = lv_label_create(switchcontainer); /*Add a label to the button*/
     lv_label_set_text(label, _entity->name.c_str()); /*Set the labels text*/
-
-    std::cerr << "CREATED switch FOR " << entity->name << std::endl;
+    uiupdate();
   }
 
   void uiupdate() override

--- a/src/UIComponents.hpp
+++ b/src/UIComponents.hpp
@@ -21,6 +21,17 @@ protected:
   lv_obj_t* parentContainer;
 };
 
+static void btn_press_cb(lv_event_t* e)
+{
+  lv_event_code_t code = lv_event_get_code(e);
+
+  std::shared_ptr<HAEntity> ent = *reinterpret_cast<std::shared_ptr<HAEntity>*>(e->user_data);
+  if (code == LV_EVENT_VALUE_CHANGED) {
+    HADomains::Light light(ent);
+    light.toggle({});
+  }
+}
+
 class UIButton : UIEntity
 {
 public:
@@ -29,10 +40,10 @@ public:
   {
     // START BUTTON EXAMPLE
     lv_obj_t* btn = lv_btn_create(_parent); /*Add a button the current screen*/
-    lv_obj_set_pos(btn, 10, 10); /*Set its position*/
-    lv_obj_set_size(btn, 240, 30); /*Set its size*/
+    lv_obj_set_size(btn, 240, 50);
+    lv_obj_center(btn);
     lv_obj_add_flag(btn, LV_OBJ_FLAG_CHECKABLE);
-    lv_obj_add_event_cb(btn, UIButton::btn_press_cb, LV_EVENT_ALL, reinterpret_cast<void*>(&_entity)); /*Assign a callback to the button*/
+    lv_obj_add_event_cb(btn, btn_press_cb, LV_EVENT_ALL, reinterpret_cast<void*>(&_entity)); /*Assign a callback to the button*/
 
     lv_obj_t* label = lv_label_create(btn); /*Add a label to the button*/
     lv_label_set_text(label, _entity->name.c_str()); /*Set the labels text*/
@@ -40,15 +51,26 @@ public:
   }
 
 private:
-  static void btn_press_cb(lv_event_t* e)
-  {
-    lv_event_code_t code = lv_event_get_code(e);
+};
 
-    std::shared_ptr<HAEntity> ent = *reinterpret_cast<std::shared_ptr<HAEntity>*>(e->user_data);
-    if (code == LV_EVENT_VALUE_CHANGED) {
-      HADomains::Light light(ent);
-      light.toggle({});
-    }
+class UISwitch : UIEntity
+{
+public:
+  UISwitch(std::shared_ptr<HAEntity> _entity, lv_obj_t* _parent) :
+    UIEntity(_entity, _parent)
+  {
+    // START BUTTON EXAMPLE
+    lv_obj_t* switchcontainer = lv_obj_create(_parent);
+    lv_obj_set_size(switchcontainer, 240, 50);
+    lv_obj_center(switchcontainer);
+
+    lv_obj_t* sw = lv_switch_create(switchcontainer); /*Add a button the current screen*/
+    lv_obj_add_event_cb(sw, btn_press_cb, LV_EVENT_ALL, reinterpret_cast<void*>(&_entity)); /*Assign a callback to the button*/
+    lv_obj_add_flag(sw, LV_OBJ_FLAG_EVENT_BUBBLE);
+    lv_obj_set_align(sw, LV_ALIGN_RIGHT_MID);
+
+    lv_obj_t* label = lv_label_create(switchcontainer); /*Add a label to the button*/
+    lv_label_set_text(label, _entity->name.c_str()); /*Set the labels text*/
   }
 };
 

--- a/src/UIComponents.hpp
+++ b/src/UIComponents.hpp
@@ -31,7 +31,7 @@ public:
     lv_obj_t* btn = lv_btn_create(_parent); /*Add a button the current screen*/
     lv_obj_set_pos(btn, 10, 10); /*Set its position*/
     lv_obj_set_size(btn, 240, 50); /*Set its size*/
-    lv_obj_add_event_cb(btn, UISwitch::btn_press_cb, LV_EVENT_ALL, NULL); /*Assign a callback to the button*/
+    lv_obj_add_event_cb(btn, UISwitch::btn_press_cb, LV_EVENT_ALL, reinterpret_cast<void*>(&_entity)); /*Assign a callback to the button*/
 
     lv_obj_t* label = lv_label_create(btn); /*Add a label to the button*/
     lv_label_set_text(label, _entity->name.c_str()); /*Set the labels text*/
@@ -42,8 +42,10 @@ private:
   static void btn_press_cb(lv_event_t* e)
   {
     lv_event_code_t code = lv_event_get_code(e);
+
+    std::shared_ptr<HAEntity> ent = *reinterpret_cast<std::shared_ptr<HAEntity>*>(e->user_data);
     if (code == LV_EVENT_CLICKED) {
-      HADomains::Light light(entity);
+      HADomains::Light light(ent);
       light.toggle({});
     }
   }

--- a/src/UIComponents.hpp
+++ b/src/UIComponents.hpp
@@ -5,15 +5,21 @@
 #include "HAEntity.hpp"
 #include "Backend.hpp"
 #include <lvgl.h>
+#include "Observer.hpp"
 #include "generated/domains.hpp"
 
-class UIEntity
+class UIEntity : public IObserver
 {
 public:
+  ~UIEntity()
+  {
+    entity->detach((IObserver*)this);
+  };
   UIEntity(std::shared_ptr<HAEntity> _entity, lv_obj_t* _parent)
   {
     parentContainer = _parent;
     entity = _entity;
+    entity->attach((IObserver*)this);
   }
 
 protected:
@@ -32,9 +38,10 @@ static void btn_press_cb(lv_event_t* e)
   }
 }
 
-class UIButton : UIEntity
+class UIButton : public UIEntity
 {
 public:
+  ~UIButton(){};
   UIButton(std::shared_ptr<HAEntity> _entity, lv_obj_t* _parent) :
     UIEntity(_entity, _parent)
   {
@@ -50,12 +57,19 @@ public:
     lv_obj_center(label);
   }
 
+  void uiupdate() override
+  {
+    auto state = entity->getJsonState();
+    std::cerr << "STATE IS:" << state << std::endl;
+  }
+
 private:
 };
 
-class UISwitch : UIEntity
+class UISwitch : public UIEntity
 {
 public:
+  ~UISwitch() {}
   UISwitch(std::shared_ptr<HAEntity> _entity, lv_obj_t* _parent) :
     UIEntity(_entity, _parent)
   {
@@ -71,6 +85,12 @@ public:
 
     lv_obj_t* label = lv_label_create(switchcontainer); /*Add a label to the button*/
     lv_label_set_text(label, _entity->name.c_str()); /*Set the labels text*/
+  }
+
+  void uiupdate() override
+  {
+    auto state = entity->getJsonState();
+    std::cerr << "STATE IS:" << state << std::endl;
   }
 };
 

--- a/src/UIComponents.hpp
+++ b/src/UIComponents.hpp
@@ -8,17 +8,6 @@
 #include "Observer.hpp"
 #include "generated/domains.hpp"
 
-static void btn_press_cb(lv_event_t* e)
-{
-  lv_event_code_t code = lv_event_get_code(e);
-
-  std::shared_ptr<HAEntity> ent = *reinterpret_cast<std::shared_ptr<HAEntity>*>(e->user_data);
-  if (code == LV_EVENT_VALUE_CHANGED) {
-    HADomains::Light light(ent);
-    light.toggle({});
-  }
-}
-
 class UIEntity : public IObserver
 {
 public:
@@ -38,6 +27,7 @@ public:
 
 private:
   lv_obj_t* btn;
+  static void btn_press_cb(lv_event_t* e);
 };
 
 class UISwitch : public UIEntity
@@ -49,6 +39,7 @@ public:
 
 private:
   lv_obj_t* sw;
+  static void sw_toggle_cb(lv_event_t* e);
 };
 
 #endif

--- a/src/UIComponents.hpp
+++ b/src/UIComponents.hpp
@@ -1,0 +1,36 @@
+
+#ifndef UICOMPONENTS_HPP
+#define UICOMPONENTS_HPP
+
+#include "HAEntity.hpp"
+#include <lvgl.h>
+
+class UIEntity
+{
+public:
+  UIEntity(HAEntity _entity, lv_obj_t* _parent)
+  {
+    parentContainer = _parent;
+    entity = _entity;
+  }
+
+private:
+  HAEntity entity;
+  lv_obj_t* parentContainer;
+};
+
+class UISwitch : UIEntity
+{
+  UISwitch(HAEntity _entity, lv_obj_t* _parent) :
+    UIEntity(_entity, _parent)
+  {
+    lv_obj_t* btn = lv_btn_create(parentContainer);
+    lv_obj_set_size(btn, 100, LV_PCT(100));
+
+    lv_obj_t* label = lv_label_create(btn);
+    lv_label_set_text_fmt(label, "On/Off");
+    lv_obj_center(label);
+  }
+};
+
+#endif

--- a/src/UIComponents.hpp
+++ b/src/UIComponents.hpp
@@ -21,17 +21,18 @@ protected:
   lv_obj_t* parentContainer;
 };
 
-class UISwitch : UIEntity
+class UIButton : UIEntity
 {
 public:
-  UISwitch(std::shared_ptr<HAEntity> _entity, lv_obj_t* _parent) :
+  UIButton(std::shared_ptr<HAEntity> _entity, lv_obj_t* _parent) :
     UIEntity(_entity, _parent)
   {
     // START BUTTON EXAMPLE
     lv_obj_t* btn = lv_btn_create(_parent); /*Add a button the current screen*/
     lv_obj_set_pos(btn, 10, 10); /*Set its position*/
-    lv_obj_set_size(btn, 240, 50); /*Set its size*/
-    lv_obj_add_event_cb(btn, UISwitch::btn_press_cb, LV_EVENT_ALL, reinterpret_cast<void*>(&_entity)); /*Assign a callback to the button*/
+    lv_obj_set_size(btn, 240, 30); /*Set its size*/
+    lv_obj_add_flag(btn, LV_OBJ_FLAG_CHECKABLE);
+    lv_obj_add_event_cb(btn, UIButton::btn_press_cb, LV_EVENT_ALL, reinterpret_cast<void*>(&_entity)); /*Assign a callback to the button*/
 
     lv_obj_t* label = lv_label_create(btn); /*Add a label to the button*/
     lv_label_set_text(label, _entity->name.c_str()); /*Set the labels text*/
@@ -44,7 +45,7 @@ private:
     lv_event_code_t code = lv_event_get_code(e);
 
     std::shared_ptr<HAEntity> ent = *reinterpret_cast<std::shared_ptr<HAEntity>*>(e->user_data);
-    if (code == LV_EVENT_CLICKED) {
+    if (code == LV_EVENT_VALUE_CHANGED) {
       HADomains::Light light(ent);
       light.toggle({});
     }

--- a/src/UIComponents.hpp
+++ b/src/UIComponents.hpp
@@ -41,7 +41,6 @@ static void btn_press_cb(lv_event_t* e)
 class UIButton : public UIEntity
 {
 public:
-  ~UIButton(){};
   UIButton(std::shared_ptr<HAEntity> _entity, lv_obj_t* _parent) :
     UIEntity(_entity, _parent)
   {
@@ -67,8 +66,6 @@ public:
     else {
       lv_obj_clear_state(btn, LV_STATE_CHECKED);
     }
-
-    std::cerr << "uiupdate - STATE IS:" << state << std::endl;
   }
 
 private:
@@ -78,7 +75,6 @@ private:
 class UISwitch : public UIEntity
 {
 public:
-  ~UISwitch() {}
   UISwitch(std::shared_ptr<HAEntity> _entity, lv_obj_t* _parent) :
     UIEntity(_entity, _parent)
   {
@@ -106,8 +102,6 @@ public:
     else {
       lv_obj_clear_state(sw, LV_STATE_CHECKED);
     }
-
-    std::cerr << "uiupdate - STATE IS:" << state << std::endl;
   }
 
 private:

--- a/src/UIComponents.hpp
+++ b/src/UIComponents.hpp
@@ -46,24 +46,33 @@ public:
     UIEntity(_entity, _parent)
   {
     // START BUTTON EXAMPLE
-    lv_obj_t* btn = lv_btn_create(_parent); /*Add a button the current screen*/
+    btn = lv_btn_create(_parent); /*Add a button the current screen*/
     lv_obj_set_size(btn, 240, 50);
     lv_obj_center(btn);
     lv_obj_add_flag(btn, LV_OBJ_FLAG_CHECKABLE);
-    lv_obj_add_event_cb(btn, btn_press_cb, LV_EVENT_ALL, reinterpret_cast<void*>(&_entity)); /*Assign a callback to the button*/
+    lv_obj_add_event_cb(btn, btn_press_cb, LV_EVENT_ALL, reinterpret_cast<void*>(&entity)); /*Assign a callback to the button*/
 
     lv_obj_t* label = lv_label_create(btn); /*Add a label to the button*/
     lv_label_set_text(label, _entity->name.c_str()); /*Set the labels text*/
     lv_obj_center(label);
+    std::cerr << "CREATED button FOR " << entity->name << std::endl;
   }
 
   void uiupdate() override
   {
     auto state = entity->getJsonState();
-    std::cerr << "STATE IS:" << state << std::endl;
+    if (state["state"] == "on") {
+      lv_obj_add_state(btn, LV_STATE_CHECKED);
+    }
+    else {
+      lv_obj_clear_state(btn, LV_STATE_CHECKED);
+    }
+
+    std::cerr << "uiupdate - STATE IS:" << state << std::endl;
   }
 
 private:
+  lv_obj_t* btn;
 };
 
 class UISwitch : public UIEntity
@@ -78,20 +87,32 @@ public:
     lv_obj_set_size(switchcontainer, 240, 50);
     lv_obj_center(switchcontainer);
 
-    lv_obj_t* sw = lv_switch_create(switchcontainer); /*Add a button the current screen*/
-    lv_obj_add_event_cb(sw, btn_press_cb, LV_EVENT_ALL, reinterpret_cast<void*>(&_entity)); /*Assign a callback to the button*/
+    sw = lv_switch_create(switchcontainer); /*Add a button the current screen*/
+    lv_obj_add_event_cb(sw, btn_press_cb, LV_EVENT_ALL, reinterpret_cast<void*>(&entity)); /*Assign a callback to the button*/
     lv_obj_add_flag(sw, LV_OBJ_FLAG_EVENT_BUBBLE);
     lv_obj_set_align(sw, LV_ALIGN_RIGHT_MID);
 
     lv_obj_t* label = lv_label_create(switchcontainer); /*Add a label to the button*/
     lv_label_set_text(label, _entity->name.c_str()); /*Set the labels text*/
+
+    std::cerr << "CREATED switch FOR " << entity->name << std::endl;
   }
 
   void uiupdate() override
   {
     auto state = entity->getJsonState();
-    std::cerr << "STATE IS:" << state << std::endl;
+    if (state["state"] == "on") {
+      lv_obj_add_state(sw, LV_STATE_CHECKED);
+    }
+    else {
+      lv_obj_clear_state(sw, LV_STATE_CHECKED);
+    }
+
+    std::cerr << "uiupdate - STATE IS:" << state << std::endl;
   }
+
+private:
+  lv_obj_t* sw;
 };
 
 #endif

--- a/src/front-cli.cpp
+++ b/src/front-cli.cpp
@@ -93,22 +93,20 @@ void uithread(HABackend& backend, int argc, char* argv[])
 
     backend.Start();
 
-    std::vector<SimpleObserver*> observers;
     auto haentities = backend.GetEntitiesByDomain(domain);
+
+    std::vector<std::unique_ptr<SimpleObserver>> observers;
+
     for (const auto& haentity : haentities) {
       std::cerr << "Registering observer for " << haentity->name << std::endl;
-      SimpleObserver* obs = new SimpleObserver(haentity);
-
-      observers.push_back(obs);
-      std::cerr << " after push back: " << observers.size() << std::endl;
-      for (auto obs : observers) {
-        obs->printHAEntity();
-      }
+      std::unique_ptr<SimpleObserver> observer = std::make_unique<SimpleObserver>(haentity);
+      observers.push_back(std::move(observer));
     }
+
     while (true) {
       sleep(10);
       std::cerr << "Nothing received: " << observers.size() << std::endl;
-      for (auto obs : observers) {
+      for (auto& obs : observers) {
         obs->printHAEntity();
       }
     }

--- a/src/front-cli.cpp
+++ b/src/front-cli.cpp
@@ -7,6 +7,7 @@
 #include <unistd.h>
 
 #include "Backend.hpp"
+#include "Observer.hpp"
 
 using std::string;
 
@@ -15,14 +16,32 @@ using std::cout;
 using std::endl;
 using std::flush;
 
+class SimpleObserver : public IObserver
+{
+public:
+  SimpleObserver(std::shared_ptr<HAEntity> _entity)
+  {
+    haentity = _entity;
+    haentity->attach((IObserver*)this);
+  }
+  void uiupdate() override
+  {
+    std::cout << "Received uiupdate for " << haentity->name << ":" << std::endl;
+    std::cout << haentity->getInfo() << std::endl;
+  }
+
+private:
+  std::shared_ptr<HAEntity> haentity;
+};
+
 static bool uithread_refresh_print_updates = false;
 
 void uithread(HABackend& backend, int argc, char* argv[])
 {
   argparse::ArgumentParser program("client-cli");
   argparse::ArgumentParser subscribe_command("subscribe");
-  subscribe_command.add_argument("pattern")
-    .help("specific state name, or *"); // maybe .remaining() so you can subscribe multiple?
+  subscribe_command.add_argument("domain")
+    .help("specific a HA domain"); // maybe .remaining() so you can subscribe multiple?
 
   program.add_subparser(subscribe_command);
 
@@ -53,13 +72,25 @@ void uithread(HABackend& backend, int argc, char* argv[])
 
   if (program.is_subcommand_used(subscribe_command)) {
     // FIXME: now actually use the argument
-    cout << "should subscribe to " << subscribe_command.get<string>("pattern") << endl;
-    uithread_refresh_print_updates = true;
+    string domain = subscribe_command.get<string>("domain");
+    if (!domain.empty()) {
+      cout << "should subscribe to " << subscribe_command.get<string>("domain") << endl;
+    }
+    else {
+      cerr << "No domain provided!" << endl;
+      return;
+    }
+
     backend.Start();
-    cout << "Backend thread started..." << endl;
+    auto haentities = backend.GetEntitiesByDomain(domain);
+    std::vector<std::unique_ptr<SimpleObserver>> observers;
+    for (auto haentity : haentities) {
+      std::cerr << "Registering observer for " << haentity->name << std::endl;
+      SimpleObserver observer(haentity);
+      observers.push_back(std::unique_ptr<SimpleObserver>(&observer));
+    }
     while (true) {
-      sleep(1);
-      cerr << "." << flush;
+      sleep(10);
     }
   }
   else if (program.is_subcommand_used(token_command)) {

--- a/src/front-cli.cpp
+++ b/src/front-cli.cpp
@@ -21,12 +21,10 @@ class SimpleObserver : public IObserver
 public:
   ~SimpleObserver()
   {
-    std::cerr << "DE-structor called on SimpleObserver for " << haentity->name << std::endl;
     haentity->detach((IObserver*)this);
   }
   SimpleObserver(std::shared_ptr<HAEntity> _entity)
   {
-    std::cerr << "Creating simpleobserver for " << _entity->name << std::endl;
     haentity = _entity;
     haentity->attach((IObserver*)this);
   }
@@ -35,16 +33,12 @@ public:
     std::cout << "Received uiupdate for " << haentity->name << ":" << std::endl;
     std::cout << haentity->getInfo() << std::endl;
   }
-  void printHAEntity()
-  {
-    std::cout << "SimpleObserver reporting: " << haentity->name << std::endl;
-  }
 
 private:
   std::shared_ptr<HAEntity> haentity;
 };
 
-static bool uithread_refresh_print_updates = false;
+// static bool uithread_refresh_print_updates = false;
 
 void uithread(HABackend& backend, int argc, char* argv[])
 {
@@ -94,21 +88,15 @@ void uithread(HABackend& backend, int argc, char* argv[])
     backend.Start();
 
     auto haentities = backend.GetEntitiesByDomain(domain);
-
     std::vector<std::unique_ptr<SimpleObserver>> observers;
-
     for (const auto& haentity : haentities) {
-      std::cerr << "Registering observer for " << haentity->name << std::endl;
+      std::cerr << "Monitoring entity: " << haentity->name << std::endl;
       std::unique_ptr<SimpleObserver> observer = std::make_unique<SimpleObserver>(haentity);
       observers.push_back(std::move(observer));
     }
 
     while (true) {
       sleep(10);
-      std::cerr << "Nothing received: " << observers.size() << std::endl;
-      for (auto& obs : observers) {
-        obs->printHAEntity();
-      }
     }
   }
   else if (program.is_subcommand_used(token_command)) {
@@ -128,18 +116,5 @@ void uithread(HABackend& backend, int argc, char* argv[])
   }
   else {
     cerr << "no command given" << endl;
-  }
-}
-
-void uithread_refresh(HABackend* backend, std::vector<std::string> whatchanged)
-{
-  if (uithread_refresh_print_updates) {
-    for (const auto& changed : whatchanged) {
-      auto state = backend->GetEntityByName(changed);
-      cout << "state for " << changed << " is " << state->getInfo() << endl;
-      for (const auto& attr : state->attrVector()) {
-        cout << "  " << attr << endl;
-      }
-    }
   }
 }

--- a/src/front-ftxui.cpp
+++ b/src/front-ftxui.cpp
@@ -113,8 +113,3 @@ void uithread(HABackend& backend, int /* argc */, char*[] /* argv[] */)
   // auto screen = ScreenInteractive::FitComponent();
   screen.Loop(renderer);
 }
-
-void uithread_refresh(HABackend* /* backend */, std::vector<std::string> /* whatchanged */)
-{
-  screen.PostEvent(ftxui::Event::Custom); // REMOVE
-}

--- a/src/front-lvgl.cpp
+++ b/src/front-lvgl.cpp
@@ -163,19 +163,23 @@ void uithread(HABackend& backend, int argc, char* argv[])
 
   /*Create a container with ROW flex direction*/
   lv_obj_t* cont_row = lv_obj_create(lv_scr_act());
-  lv_obj_set_size(cont_row, 300, 800);
+  lv_obj_set_size(cont_row, 500, 800);
   lv_obj_align(cont_row, LV_ALIGN_TOP_MID, 0, 5);
   lv_obj_set_flex_flow(cont_row, LV_FLEX_FLOW_COLUMN);
 
+  std::vector<UIEntity*> uielements;
   int i = 0;
   auto entities = backend.GetEntitiesByDomain("light");
   for (auto entity : entities) {
+    UIEntity* element;
     if (i % 2 == 0) {
-      UIButton(entity, cont_row);
+      element = (UIEntity*)new UIButton(entity, cont_row);
     }
     else {
-      UISwitch(entity, cont_row);
+
+      element = (UIEntity*)new UISwitch(entity, cont_row);
     }
+    uielements.push_back(element);
     i++;
   }
 
@@ -261,15 +265,15 @@ void uithread_refresh(HABackend* backend, std::vector<std::string> whatchanged) 
   // return;
   // std::scoped_lock lk(entrieslock, stateslock, domainslock);
 
-  cerr << whatchanged.size() << endl;
+  cout << "Changes: " << whatchanged.size() << endl;
   for (const auto& changed : whatchanged) {
     auto state = backend->GetEntityByName(changed);
     cout << "state for " << changed << " is " << state->getInfo() << endl;
     auto attrs = state->getJsonState()["attributes"];
-    cout << attrs << endl;
-    if (state->getEntityType() == EntityType::Light) {
-      // current_light = changed;  moved to a command line flag for now
-    }
+    //    cout << attrs << endl;
+    //   if (state->getEntityType() == EntityType::Light) {
+    // current_light = changed;  moved to a command line flag for now
+    // }
     // if(attrs.count("rgb_color")) {
     //     auto rgb = attrs["rgb_color"];
     //     cout<<"RGB "<<rgb<<endl;
@@ -279,8 +283,8 @@ void uithread_refresh(HABackend* backend, std::vector<std::string> whatchanged) 
     //         c=color;
     //     }
     // }
-    for (const auto& attr : state->attrVector()) {
-      cout << "  " << attr << endl;
-    }
+    // for (const auto& attr : state->attrVector()) {
+    //  cout << "  " << attr << endl;
+    //}
   }
 }

--- a/src/front-lvgl.cpp
+++ b/src/front-lvgl.cpp
@@ -167,12 +167,19 @@ void uithread(HABackend& backend, int argc, char* argv[])
   lv_obj_align(cont_row, LV_ALIGN_TOP_MID, 0, 5);
   lv_obj_set_flex_flow(cont_row, LV_FLEX_FLOW_COLUMN);
 
+  int i = 0;
   auto entities = backend.GetEntitiesByDomain("light");
   for (auto entity : entities) {
-    UIButton(entity, cont_row);
+    if (i % 2 == 0) {
+      UIButton(entity, cont_row);
+    }
+    else {
+      UISwitch(entity, cont_row);
+    }
+    i++;
   }
 
-  int i = 0;
+  i = 0;
   while (true) {
     usleep(5 * 1000); // 5000 usec = 5 ms
     lv_tick_inc(5); // 5 ms

--- a/src/front-lvgl.cpp
+++ b/src/front-lvgl.cpp
@@ -168,7 +168,7 @@ void uithread(HABackend& backend, int argc, char* argv[])
   std::vector<std::unique_ptr<UIEntity>> uielements;
   int i = 0;
   auto entities = backend.GetEntitiesByDomain("light");
-  for (auto entity : entities) {
+  for (const auto& entity : entities) {
     if (i % 2 == 0) {
       std::unique_ptr<UIEntity> btn = std::make_unique<UIButton>(entity, cont_row);
       uielements.push_back(std::move(btn));

--- a/src/front-lvgl.cpp
+++ b/src/front-lvgl.cpp
@@ -170,13 +170,14 @@ void uithread(HABackend& backend, int argc, char* argv[])
   auto entities = backend.GetEntitiesByDomain("light");
   for (auto entity : entities) {
     if (i % 2 == 0) {
-      UIButton btn(entity, cont_row);
-      uielements.push_back(std::unique_ptr<UIEntity>(&btn));
+      std::unique_ptr<UIEntity> btn = std::make_unique<UIButton>(entity, cont_row);
+      uielements.push_back(std::move(btn));
     }
     else {
-      UISwitch sw(entity, cont_row);
-      uielements.push_back(std::unique_ptr<UIEntity>(&sw));
+      std::unique_ptr<UIEntity> btn = std::make_unique<UISwitch>(entity, cont_row);
+      uielements.push_back(std::move(btn));
     }
+
     i++;
   }
 

--- a/src/front-lvgl.cpp
+++ b/src/front-lvgl.cpp
@@ -163,13 +163,24 @@ void uithread(HABackend& backend, int argc, char* argv[])
 
   /*Create a container with ROW flex direction*/
   lv_obj_t* cont_row = lv_obj_create(lv_scr_act());
-  lv_obj_set_size(cont_row, 300, 75);
+  lv_obj_set_size(cont_row, 300, 800);
   lv_obj_align(cont_row, LV_ALIGN_TOP_MID, 0, 5);
   lv_obj_set_flex_flow(cont_row, LV_FLEX_FLOW_ROW);
 
   auto entities = backend.GetEntitiesByDomain("light");
   for (auto entity : entities) {
     UISwitch(entity, cont_row);
+  }
+
+  int i = 0;
+  while (true) {
+    usleep(5 * 1000); // 5000 usec = 5 ms
+    lv_tick_inc(5); // 5 ms
+    lv_task_handler();
+    if (i++ == (1000 / 5)) {
+      cerr << "." << flush;
+      i = 0;
+    }
   }
 
   // int i = 0;

--- a/src/front-lvgl.cpp
+++ b/src/front-lvgl.cpp
@@ -37,7 +37,6 @@ static uint32_t intFromRGB(json attrs)
 }
 
 static string current_light; // FIXME: THIS NEEDS A MUTEX
-static bool toggle = false;
 static bool newcolor = false;
 
 static void btn_event_cb(lv_event_t* e)
@@ -45,7 +44,6 @@ static void btn_event_cb(lv_event_t* e)
   lv_event_code_t code = lv_event_get_code(e);
   // lv_obj_t* btn = lv_event_get_target(e);
   if (code == LV_EVENT_CLICKED) {
-    toggle = true;
     // static uint32_t cnt = 0;
     // cnt++;
 
@@ -195,17 +193,6 @@ void uithread(HABackend& backend, int argc, char* argv[])
 
   // int i = 0;
   // while (true) {
-  //   if (toggle) {
-  //     json cmd;
-
-  //     auto entity = backend.GetEntityByName(current_light);
-  //     HADomains::Light light(entity);
-
-  //     light.toggle({});
-
-  //     toggle = false;
-  //   }
-
   //   if (newcolor) {
   //     json cmd;
   //     json rgb;
@@ -257,33 +244,4 @@ void uithread(HABackend& backend, int argc, char* argv[])
   //   i = 0;
   // }
   //}
-}
-
-void uithread_refresh(HABackend* backend, std::vector<std::string> whatchanged) // would be cool if this got told what changed
-{
-  // return;
-  // std::scoped_lock lk(entrieslock, stateslock, domainslock);
-
-  cout << "Changes: " << whatchanged.size() << endl;
-  for (const auto& changed : whatchanged) {
-    auto state = backend->GetEntityByName(changed);
-    cout << "state for " << changed << " is " << state->getInfo() << endl;
-    auto attrs = state->getJsonState()["attributes"];
-    //    cout << attrs << endl;
-    //   if (state->getEntityType() == EntityType::Light) {
-    // current_light = changed;  moved to a command line flag for now
-    // }
-    // if(attrs.count("rgb_color")) {
-    //     auto rgb = attrs["rgb_color"];
-    //     cout<<"RGB "<<rgb<<endl;
-    //     if (rgb.size() == 3) {
-    //         uint32_t color = (rgb[0].get<int>() << 16) + (rgb[1].get<int>() << 8) + (rgb[2].get<int>());
-    //         cout<<" "<<color;
-    //         c=color;
-    //     }
-    // }
-    // for (const auto& attr : state->attrVector()) {
-    //  cout << "  " << attr << endl;
-    //}
-  }
 }

--- a/src/front-lvgl.cpp
+++ b/src/front-lvgl.cpp
@@ -10,7 +10,7 @@
 #include <src/core/lv_disp.h>
 #include <utility>
 #include "sdl/sdl.h"
-
+#include "UIComponents.hpp"
 #include <generated/domains.hpp>
 
 using std::string;
@@ -134,97 +134,108 @@ void uithread(HABackend& backend, int argc, char* argv[])
   lv_group_t* g = lv_group_create();
   lv_group_set_default(g);
 
-  // START BUTTON EXAMPLE
-  lv_obj_t* btn = lv_btn_create(lv_scr_act()); /*Add a button the current screen*/
-  lv_obj_set_pos(btn, 10, 10); /*Set its position*/
-  lv_obj_set_size(btn, 240, 50); /*Set its size*/
-  lv_obj_add_event_cb(btn, btn_event_cb, LV_EVENT_ALL, NULL); /*Assign a callback to the button*/
+  // // START BUTTON EXAMPLE
+  // lv_obj_t* btn = lv_btn_create(lv_scr_act()); /*Add a button the current screen*/
+  // lv_obj_set_pos(btn, 10, 10); /*Set its position*/
+  // lv_obj_set_size(btn, 240, 50); /*Set its size*/
+  // lv_obj_add_event_cb(btn, btn_event_cb, LV_EVENT_ALL, NULL); /*Assign a callback to the button*/
 
-  lv_obj_t* label = lv_label_create(btn); /*Add a label to the button*/
-  lv_label_set_text(label, "Button"); /*Set the labels text*/
-  lv_obj_center(label);
-  // END BUTTON EXAMPLE
-  for (int i = 0; i < 3; i++) {
+  // lv_obj_t* label = lv_label_create(btn); /*Add a label to the button*/
+  // lv_label_set_text(label, "Button"); /*Set the labels text*/
+  // lv_obj_center(label);
+  // // END BUTTON EXAMPLE
+  // for (int i = 0; i < 3; i++) {
 
-    /*Create a slider in the center of the display*/
-    lv_obj_t* slider = lv_slider_create(lv_scr_act());
-    lv_slider_set_range(slider, 0, 255);
-    lv_obj_set_width(slider, 200); /*Set the width*/
-    lv_obj_set_pos(slider, 40, i * 70 + 120);
-    lv_obj_add_event_cb(slider, slider_event_cb, LV_EVENT_VALUE_CHANGED, NULL); /*Assign an event function*/
+  //   /*Create a slider in the center of the display*/
+  //   lv_obj_t* slider = lv_slider_create(lv_scr_act());
+  //   lv_slider_set_range(slider, 0, 255);
+  //   lv_obj_set_width(slider, 200); /*Set the width*/
+  //   lv_obj_set_pos(slider, 40, i * 70 + 120);
+  //   lv_obj_add_event_cb(slider, slider_event_cb, LV_EVENT_VALUE_CHANGED, NULL); /*Assign an event function*/
 
-    /*Create a label above the slider*/
-    lv_obj_t* slabel = lv_label_create(lv_scr_act());
-    lv_label_set_text(slabel, "0");
-    lv_obj_align_to(slabel, slider, LV_ALIGN_OUT_TOP_MID, 0, -15); /*Align top of the slider*/
+  //   /*Create a label above the slider*/
+  //   lv_obj_t* slabel = lv_label_create(lv_scr_act());
+  //   lv_label_set_text(slabel, "0");
+  //   lv_obj_align_to(slabel, slider, LV_ALIGN_OUT_TOP_MID, 0, -15); /*Align top of the slider*/
 
-    rgbsliders[i] = std::make_pair(slider, slabel);
+  //   rgbsliders[i] = std::make_pair(slider, slabel);
+  // }
+
+  /*Create a container with ROW flex direction*/
+  lv_obj_t* cont_row = lv_obj_create(lv_scr_act());
+  lv_obj_set_size(cont_row, 300, 75);
+  lv_obj_align(cont_row, LV_ALIGN_TOP_MID, 0, 5);
+  lv_obj_set_flex_flow(cont_row, LV_FLEX_FLOW_ROW);
+
+  auto entities = backend.GetEntitiesByDomain("light");
+  for (auto entity : entities) {
+    UISwitch(entity, cont_row);
   }
 
-  int i = 0;
-  while (true) {
-    if (toggle) {
-      json cmd;
+  // int i = 0;
+  // while (true) {
+  //   if (toggle) {
+  //     json cmd;
 
-      auto entity = backend.GetEntityByName(current_light);
-      HADomains::Light light(entity);
+  //     auto entity = backend.GetEntityByName(current_light);
+  //     HADomains::Light light(entity);
 
-      light.toggle({});
+  //     light.toggle({});
 
-      toggle = false;
-    }
+  //     toggle = false;
+  //   }
 
-    if (newcolor) {
-      json cmd;
-      json rgb;
+  //   if (newcolor) {
+  //     json cmd;
+  //     json rgb;
 
-      rgb = {0, 0, 0};
+  //     rgb = {0, 0, 0};
 
-      for (int i = 0; i < 3; i++) {
-        rgb[i] = lv_slider_get_value(rgbsliders[i].first);
-      }
+  //     for (int i = 0; i < 3; i++) {
+  //       rgb[i] = lv_slider_get_value(rgbsliders[i].first);
+  //     }
 
-      cmd["type"] = "call_service";
-      cmd["domain"] = backend.GetEntityByName(current_light)->domain;
-      cmd["service"] = "turn_on";
-      cmd["target"]["entity_id"] = current_light;
-      cmd["service_data"]["rgb_color"] = rgb;
+  //     cmd["type"] = "call_service";
+  //     cmd["domain"] = backend.GetEntityByName(current_light)->domain;
+  //     cmd["service"] = "turn_on";
+  //     cmd["target"]["entity_id"] = current_light;
+  //     cmd["service_data"]["rgb_color"] = rgb;
 
-      backend.WSConnSend(cmd);
+  //     backend.WSConnSend(cmd);
 
-      newcolor = false;
-    }
-    else {
-      // uint32_t c = rand();
-      auto attrs = backend.GetEntityByName(current_light)->getJsonState()["attributes"];
-      if (attrs.count("rgb_color")) {
-        auto rgb = attrs["rgb_color"];
-        // cout<<"RGB "<<rgb<<endl;
-        if (rgb.size() == 3) {
-          for (int i = 0; i < 3; i++) {
-            lv_slider_set_value(rgbsliders[i].first, rgb[i], LV_ANIM_OFF);
+  //     newcolor = false;
+  //   }
+  //   else {
+  //     // uint32_t c = rand();
+  //     auto attrs = backend.GetEntityByName(current_light)->getJsonState()["attributes"];
+  //     if (attrs.count("rgb_color")) {
+  //       auto rgb = attrs["rgb_color"];
+  //       // cout<<"RGB "<<rgb<<endl;
+  //       if (rgb.size() == 3) {
+  //         for (int i = 0; i < 3; i++) {
+  //           lv_slider_set_value(rgbsliders[i].first, rgb[i], LV_ANIM_OFF);
 
-            // this label setting code is duplicated from slider_event_cb, because LV_EVENT_VALUE_CHANGED does not fire when -we- change it (https://docs.lvgl.io/latest/en/html/widgets/slider.html)
-            // and we don't want to pass the old value back to HA (which slider_event_cb would happily do for us), because that causes a super fun oscillation
-            lv_label_set_text_fmt(rgbsliders[i].second, "%" LV_PRId32, rgb[i].get<int>());
-            lv_obj_align_to(rgbsliders[i].second, rgbsliders[i].first, LV_ALIGN_OUT_TOP_MID, 0, -15); /*Align top of the slider*/
-          }
-        }
-      }
-      lv_obj_set_style_bg_color(lv_scr_act(), lv_color_hex(intFromRGB(attrs)), LV_PART_MAIN);
-      auto state = backend.GetEntityByName(current_light);
-      auto labeltext = state->getJsonState()["attributes"]["friendly_name"].get<string>() + " (" + state->getState() + ")";
-      lv_label_set_text(label, labeltext.c_str());
-    }
+  //           // this label setting code is duplicated from slider_event_cb, because LV_EVENT_VALUE_CHANGED does not fire when -we- change it (https://docs.lvgl.io/latest/en/html/widgets/slider.html)
+  //           // and we don't want to pass the old value back to HA (which slider_event_cb would happily do for us), because that causes a super fun oscillation
+  //           lv_label_set_text_fmt(rgbsliders[i].second, "%" LV_PRId32, rgb[i].get<int>());
+  //           lv_obj_align_to(rgbsliders[i].second, rgbsliders[i].first, LV_ALIGN_OUT_TOP_MID, 0, -15); /*Align top of the slider*/
+  //         }
+  //       }
+  //     }
+  //     lv_obj_set_style_bg_color(lv_scr_act(), lv_color_hex(intFromRGB(attrs)), LV_PART_MAIN);
+  //     auto state = backend.GetEntityByName(current_light);
+  //     auto labeltext = state->getJsonState()["attributes"]["friendly_name"].get<string>() + " (" + state->getState() + ")";
+  //     lv_label_set_text(label, labeltext.c_str());
+  //   }
 
-    usleep(5 * 1000); // 5000 usec = 5 ms
-    lv_tick_inc(5); // 5 ms
-    lv_task_handler();
-    if (i++ == (1000 / 5)) {
-      cerr << "." << flush;
-      i = 0;
-    }
-  }
+  // usleep(5 * 1000); // 5000 usec = 5 ms
+  // lv_tick_inc(5); // 5 ms
+  // lv_task_handler();
+  // if (i++ == (1000 / 5)) {
+  //   cerr << "." << flush;
+  //   i = 0;
+  // }
+  //}
 }
 
 void uithread_refresh(HABackend* backend, std::vector<std::string> whatchanged) // would be cool if this got told what changed

--- a/src/front-lvgl.cpp
+++ b/src/front-lvgl.cpp
@@ -74,7 +74,7 @@ static void slider_event_cb(lv_event_t* e)
 
 void uithread(HABackend& backend, int argc, char* argv[])
 {
-  argparse::ArgumentParser program("client-cli");
+  argparse::ArgumentParser program("client-lvgl");
 
   argparse::ArgumentParser entity_command("entity");
   entity_command.add_argument("name")

--- a/src/front-lvgl.cpp
+++ b/src/front-lvgl.cpp
@@ -167,19 +167,18 @@ void uithread(HABackend& backend, int argc, char* argv[])
   lv_obj_align(cont_row, LV_ALIGN_TOP_MID, 0, 5);
   lv_obj_set_flex_flow(cont_row, LV_FLEX_FLOW_COLUMN);
 
-  std::vector<UIEntity*> uielements;
+  std::vector<std::unique_ptr<UIEntity>> uielements;
   int i = 0;
   auto entities = backend.GetEntitiesByDomain("light");
   for (auto entity : entities) {
-    UIEntity* element;
     if (i % 2 == 0) {
-      element = (UIEntity*)new UIButton(entity, cont_row);
+      UIButton btn(entity, cont_row);
+      uielements.push_back(std::unique_ptr<UIEntity>(&btn));
     }
     else {
-
-      element = (UIEntity*)new UISwitch(entity, cont_row);
+      UISwitch sw(entity, cont_row);
+      uielements.push_back(std::unique_ptr<UIEntity>(&sw));
     }
-    uielements.push_back(element);
     i++;
   }
 

--- a/src/front-lvgl.cpp
+++ b/src/front-lvgl.cpp
@@ -131,8 +131,8 @@ void uithread(HABackend& backend, int argc, char* argv[])
   enc_drv.read_cb = sdl_mouse_read;
   /*lv_indev_t* enc_indev = */ lv_indev_drv_register(&enc_drv);
   // lv_indev_set_group(enc_indev, g);
-  lv_group_t* g = lv_group_create();
-  lv_group_set_default(g);
+  // lv_group_t* g = lv_group_create();
+  // lv_group_set_default(g);
 
   // // START BUTTON EXAMPLE
   // lv_obj_t* btn = lv_btn_create(lv_scr_act()); /*Add a button the current screen*/
@@ -163,7 +163,7 @@ void uithread(HABackend& backend, int argc, char* argv[])
 
   /*Create a container with ROW flex direction*/
   lv_obj_t* cont_row = lv_obj_create(lv_scr_act());
-  lv_obj_set_size(cont_row, 500, 800);
+  lv_obj_set_size(cont_row, 500, MY_DISP_HOR_RES);
   lv_obj_align(cont_row, LV_ALIGN_TOP_MID, 0, 5);
   lv_obj_set_flex_flow(cont_row, LV_FLEX_FLOW_COLUMN);
 

--- a/src/front-lvgl.cpp
+++ b/src/front-lvgl.cpp
@@ -165,11 +165,11 @@ void uithread(HABackend& backend, int argc, char* argv[])
   lv_obj_t* cont_row = lv_obj_create(lv_scr_act());
   lv_obj_set_size(cont_row, 300, 800);
   lv_obj_align(cont_row, LV_ALIGN_TOP_MID, 0, 5);
-  lv_obj_set_flex_flow(cont_row, LV_FLEX_FLOW_ROW);
+  lv_obj_set_flex_flow(cont_row, LV_FLEX_FLOW_COLUMN);
 
   auto entities = backend.GetEntitiesByDomain("light");
   for (auto entity : entities) {
-    UISwitch(entity, cont_row);
+    UIButton(entity, cont_row);
   }
 
   int i = 0;

--- a/src/main.hpp
+++ b/src/main.hpp
@@ -13,15 +13,7 @@
 #include "WSConn.hpp"
 
 using std::string;
-// using std::map;
 
 using json = nlohmann::json;
 
 std::string GetEnv(std::string key);
-// void backToFrontPing();
-
-// extern void uithread(WSConn& wc, int argc=0, char* argv[] = nullptr);
-
-extern void uithread_refresh(HABackend* backend, std::vector<std::string> whatchanged); // FIXME: I think the UI should be an object on which this is just a method?
-
-/// extern std::vector<std::string> getServicesForDomain(std::string domain); // REMOVE


### PR DESCRIPTION
This adds:
- a UIEntity base class
- 2 very basic uientity subclasses (UIBUtton and UISwitch)
- An observer/subject interface so that HAEntity can notify the UIentity of any updates
- Moves the `client-lvgl` to a list of button/switch controls in a flexbox
- removes the uithread_refresh stuff and move over to the observer pattern where needed
- cleans up some of the stuff we don't need anymore due to the above changes.