### PR TITLE
Move to normal malloc things

### DIFF
--- a/src/lv_conf.h
+++ b/src/lv_conf.h
@@ -46,7 +46,7 @@
  *=========================*/
 
 /*1: use custom malloc/free, 0: use the built-in `lv_mem_alloc()` and `lv_mem_free()`*/
-#define LV_MEM_CUSTOM 0
+#define LV_MEM_CUSTOM 1
 #if LV_MEM_CUSTOM == 0
     /*Size of the memory available for `lv_mem_alloc()` in bytes (>= 2kB)*/
     #define LV_MEM_SIZE (48U * 1024U)          /*[bytes]*/


### PR DESCRIPTION
"by default" LVGL has it's own memory management. This change moves us more to the malloc/free calls that most OS's have. This works better for us, as there seems to be an issue on mac/linux with the lvgl memory management and creating many buttons after each other.

This will probably not work on ESP or other embedded devices, which makes it more logical why lvgl choose this as the default.