### PR TITLE
turn websocket close from a confusing error into a clear one

### DIFF
--- a/src/WSConn.cpp
+++ b/src/WSConn.cpp
@@ -1,5 +1,6 @@
 
 #include "WSConn.hpp"
+#include "src/logger.hpp"
 #include <iostream>
 
 using std::cout;
@@ -66,6 +67,17 @@ std::string WSConn::recv(void)
   // cout<<"RESULT:"<<endl;
   // cout<<result<<endl;
   // cout<<"END RESULT"<<endl;
+
+  if (meta->flags & CURLWS_CLOSE) {
+    uint16_t reason = 0;
+
+    if (result.size() >= 2) {
+      reason = ((unsigned char)result[0] << 8) + (unsigned char)result[1];
+    }
+    g_log << Logger::LogLevel::Error << "got CURL_WS_CLOSE, reason=" << reason << endl;
+    throw std::runtime_error("HA websocket disconnected");
+  }
+
   return result;
 }
 


### PR DESCRIPTION
before:
```
* WS-DEC: passing [CLOSE payload=2/2]
terminate called after throwing an instance of 'nlohmann::json_abi_v3_11_2::detail::parse_error'
  what():  [json.exception.parse_error.101] parse error at line 1, column 1: syntax error while parsing value - invalid literal; last read: '<U+0003>'
Aborted
```

after:

```
* WS-DEC: passing [CLOSE payload=2/2]
2024-09-07 14:10:26 [ERROR][recv in ../src/WSConn.cpp:77] got CURL_WS_CLOSE, reason=1000
terminate called after throwing an instance of 'std::runtime_error'
  what():  HA websocket disconnected
Aborted (core dumped)
```