### PR TITLE
use B612 Regular size 16 for logbox

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Update apt indexes
         run: sudo apt-get update
       - name: Install various apt dependencies
-        run: sudo apt-get install build-essential cmake ninja-build nlohmann-json3-dev pkg-config libssl-dev libsdl2-dev python3-pip meson
+        run: sudo apt-get install build-essential cmake ninja-build nlohmann-json3-dev pkg-config libssl-dev libsdl2-dev python3-pip meson xxd
       - name: Configure Meson
         run: meson setup ${{github.workspace}}/build
       - name: Build
@@ -54,7 +54,7 @@ jobs:
       - name: Update apt indexes
         run: apt-get update
       - name: Install various apt dependencies
-        run: apt-get install -y build-essential cmake ninja-build nlohmann-json3-dev pkg-config libssl-dev libsdl2-dev muon-meson git python3-pip clang-tidy clang-format
+        run: apt-get install -y build-essential cmake ninja-build nlohmann-json3-dev pkg-config libssl-dev libsdl2-dev muon-meson git python3-pip clang-tidy clang-format xxd
       - uses: actions/checkout@v4
         with:
           submodules: recursive

--- a/.gitmodules
+++ b/.gitmodules
@@ -10,3 +10,6 @@
 [submodule "subprojects/quickjs"]
 	path = subprojects/quickjs
 	url = https://github.com/quickjs-ng/quickjs
+[submodule "src/fonts/polarsys-b612"]
+	path = src/fonts/polarsys-b612
+	url = https://github.com/polarsys/b612/

--- a/meson.build
+++ b/meson.build
@@ -63,6 +63,20 @@ curl_dep = dependency(
     ],
 )
 
+xxd_prog = find_program('xxd', required: true)
+xxd_generator = generator(
+    xxd_prog,
+    output: '@PLAINNAME@.c',
+    arguments: ['-n', '@EXTRA_ARGS@', '-i', '@INPUT@', '@OUTPUT@'],
+)
+
+# FIXME: the explicit 'B612_Regular_ttf' below would ideally be @PLAINNAME@.underscorify() above except substitution does not work there
+
+font_b612_c = xxd_generator.process(
+    'src/fonts/polarsys-b612/fonts/ttf/B612-Regular.ttf',
+    extra_args: 'B612_Regular_ttf',
+)
+
 brew_prefix = '/opt/homebrew/include'
 brew = find_program('brew', required: false)
 if brew.found()
@@ -218,6 +232,7 @@ if get_option('front-lvgl').enabled()
             'src/uicomponents/UIComponents.cpp',
             'src/front-lvgl.cpp',
             'src/lv_conf.h',
+            font_b612_c,
             'src/generated/domains.hpp',
             version_file,
         ],

--- a/scripts/build-targets/Dockerfile.armel
+++ b/scripts/build-targets/Dockerfile.armel
@@ -1,6 +1,6 @@
 FROM arm32v5/debian:bookworm
 RUN apt-get update
-RUN apt-get -yy install build-essential git cmake ninja-build nlohmann-json3-dev pkg-config libssl-dev
+RUN apt-get -yy install build-essential git cmake ninja-build nlohmann-json3-dev pkg-config libssl-dev xxd
 RUN apt-get -yy install python3-pip
 RUN pip install --break-system-packages meson
 RUN git config --global --add safe.directory '*'  # this makes meson's vcs_tag() work

--- a/src/front-lvgl.cpp
+++ b/src/front-lvgl.cpp
@@ -10,8 +10,10 @@
 #include <src/core/lv_obj_pos.h>
 #include <src/core/lv_obj_scroll.h>
 #include <src/core/lv_obj_style.h>
+#include <src/font/lv_font.h>
 #include <src/font/lv_symbol_def.h>
 #include <src/indev/lv_indev.h>
+#include <src/libs/tiny_ttf/lv_tiny_ttf.h>
 #include <src/misc/lv_anim.h>
 #include <src/misc/lv_area.h>
 #include <src/misc/lv_style.h>
@@ -20,6 +22,9 @@
 #define MY_DISP_HOR_RES 800
 #define MY_DISP_VER_RES 480
 #define DISP_BUF_SIZE 16384
+
+extern unsigned char B612_Regular_ttf[];
+extern unsigned int B612_Regular_ttf_len;
 
 std::mutex g_lvgl_updatelock;
 lv_obj_t* cont_row;
@@ -144,6 +149,11 @@ void uithread(int _argc, char* _argv[])
   // lv_group_t* g = lv_group_create();
   // lv_group_set_default(g);
 
+  static lv_font_t* B612font = lv_tiny_ttf_create_data_ex(B612_Regular_ttf, B612_Regular_ttf_len, 16, LV_FONT_KERNING_NORMAL, 1024);
+  static lv_style_t B612style;
+  lv_style_init(&B612style);
+  lv_style_set_text_font(&B612style, B612font);
+
   /* container for object row (top 80% of screen) and logs (bottom 20%) */
   lv_obj_t* row_and_logs = lv_obj_create(lv_scr_act());
   lv_obj_remove_style_all(row_and_logs);
@@ -181,7 +191,7 @@ void uithread(int _argc, char* _argv[])
   lv_label_set_text(left_btn_txt, LV_SYMBOL_LEFT);
   lv_obj_add_event_cb(left_btn, btnLeftPress, LV_EVENT_CLICKED, NULL);
 
-  UILogBox logbox(bottom_row);
+  UILogBox logbox(bottom_row, &B612style);
 
   lv_obj_t* right_btn = lv_button_create(bottom_row);
   lv_obj_t* right_btn_txt = lv_label_create(right_btn);

--- a/src/lv_conf.h
+++ b/src/lv_conf.h
@@ -617,7 +617,7 @@
 /*API for fopen, fread, etc*/
 #define LV_USE_FS_STDIO 0
 #if LV_USE_FS_STDIO
-    #define LV_FS_STDIO_LETTER '\0'     /*Set an upper cased letter on which the drive will accessible (e.g. 'A')*/
+    #define LV_FS_STDIO_LETTER 'A'     /*Set an upper cased letter on which the drive will accessible (e.g. 'A')*/
     #define LV_FS_STDIO_PATH ""         /*Set the working directory. File/directory paths will be appended to it.*/
     #define LV_FS_STDIO_CACHE_SIZE 0    /*>0 to cache this number of bytes in lv_fs_read()*/
 #endif
@@ -706,10 +706,10 @@
 #endif
 
 /* Built-in TTF decoder */
-#define LV_USE_TINY_TTF 0
+#define LV_USE_TINY_TTF 1
 #if LV_USE_TINY_TTF
     /* Enable loading TTF data from files */
-    #define LV_TINY_TTF_FILE_SUPPORT 0
+    #define LV_TINY_TTF_FILE_SUPPORT 1
 #endif
 
 /*Rlottie library*/

--- a/src/uicomponents/UILogBox.cpp
+++ b/src/uicomponents/UILogBox.cpp
@@ -3,7 +3,7 @@
 #include "logger.hpp"
 #include "uicomponents/UIComponents.hpp"
 
-UILogBox::UILogBox(lv_obj_t* _parent) :
+UILogBox::UILogBox(lv_obj_t* _parent, lv_style_t* _style) :
   UIComponent(_parent)
 {
   /* logger box */
@@ -12,6 +12,7 @@ UILogBox::UILogBox(lv_obj_t* _parent) :
   lv_obj_set_flex_align(log_box, LV_FLEX_ALIGN_START, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_START);
   lv_obj_set_flex_grow(log_box, 1);
   lv_textarea_set_placeholder_text(log_box, "No log...");
+  lv_obj_add_style(log_box, _style, 0);
   g_log.attach((IObserver*)this);
 }
 

--- a/src/uicomponents/UILogBox.hpp
+++ b/src/uicomponents/UILogBox.hpp
@@ -6,7 +6,7 @@
 class UILogBox : public UIComponent
 {
 public:
-  UILogBox(lv_obj_t* _parent);
+  UILogBox(lv_obj_t* _parent, lv_style_t* _style);
   ~UILogBox();
   void updateIfNeeded();
 


### PR DESCRIPTION
PRing this just to have it saved somewhere. the tiny TTF engine is extremely slow for our logbox, not sure why. It might be fine for other things, which is easy to test on top of this PR.

voorkant-lvgl now expects the .ttf file to be in the working directory, which is not what we want either.