### PR TITLE
armel: run on ubicloud

### DIFF
--- a/.github/workflows/main-armel.yml
+++ b/.github/workflows/main-armel.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   build-armel:
-    runs-on: ubicloud-standard-2-arm
+    runs-on: ${{ github.repository == 'voorkant/voorkant-core' && 'ubicloud-standard-2-arm' || 'ubuntu-latest' }}
     steps:
     - uses: actions/checkout@v4
       with:

--- a/.github/workflows/main-armel.yml
+++ b/.github/workflows/main-armel.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   build-armel:
-    runs-on: ubuntu-latest
+    runs-on: ubicloud-standard-2-arm
     steps:
     - uses: actions/checkout@v4
       with:
@@ -23,9 +23,9 @@ jobs:
     - name: Build armel image
       run: cd scripts/build-targets && make armel
     - name: Configure Meson
-      run: scripts/build-targets/run armel sh -c 'LDFLAGS="-static -latomic" meson setup build-armel --prefer-static -Dbuildtype=release -Dlvgl-driver=fbdev'
+      run: scripts/build-targets/run armel sh -c 'LDFLAGS="-static -latomic" linux32 meson setup build-armel --prefer-static -Dbuildtype=release -Dlvgl-driver=fbdev'
     - name: Build
-      run: scripts/build-targets/run armel sh -c 'meson compile -C build-armel'
+      run: scripts/build-targets/run armel sh -c 'linux32 meson compile -C build-armel'
     # FIXME: put something useful (git hash?) in artifact name. We also want this in other workflows.
     - uses: actions/upload-artifact@v4
       with:


### PR DESCRIPTION
It's important to note that this breaks armel builds on forks. I suspect (but have not tried) that those forks can make them work by creating a runner group called `ubicloud-standard-2-arm` that will then run on GH runners and use qemu.