### PR TITLE
make ^C work on these runs

### DIFF
--- a/scripts/build-targets/Dockerfile.armel
+++ b/scripts/build-targets/Dockerfile.armel
@@ -9,6 +9,10 @@ RUN apt-get -yy install \
     pkg-config \
     libssl-dev \
     python3-pip \
-    xxd
+    xxd \
+    tini
 RUN pip install --break-system-packages meson
 RUN git config --global --add safe.directory '*'  # this makes meson's vcs_tag() work
+ENV PYTHONUNBUFFERED=1
+ENTRYPOINT ["/usr/bin/tini", "-g", "--"]
+CMD ["/bin/sh"]

--- a/scripts/build-targets/run
+++ b/scripts/build-targets/run
@@ -1,4 +1,4 @@
 #!/bin/sh
 TARGET=$1
 shift
-docker run -v $(pwd):$(pwd) -w $(pwd) --rm voorkant-builder:$TARGET "$@"
+docker run -i -v $(pwd):$(pwd) -w $(pwd) --rm voorkant-builder:$TARGET "$@"


### PR DESCRIPTION
this looks bigger than it needs to because the simple fix (add -t to docker run) breaks CI runs

I believe this is good now, but it needs #141 first to test it well