### PR TITLE
remove pre-installed cmake from github ubuntu runner image

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,6 +14,10 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
+      # https://github.com/mesonbuild/meson/issues/13888 - CMake 3.31.0 causes breakage with cmake module due to --dependency-file
+      # https://github.com/actions/runner-images/releases/tag/ubuntu24%2F20241112.1 - upgrades /usr/local/bin/cmake from 3.30.5 to 3.31.0
+      - name: Remove pre-installed cmake
+        run: sudo rm -f /usr/local/bin/cmake
       - name: Update apt indexes
         run: sudo apt-get update
       - name: Install various apt dependencies


### PR DESCRIPTION
this unbreaks our ubuntu build. See comments in diff for the why/how.