### PR TITLE
armel build: use FROM --platform

### DIFF
--- a/scripts/build-targets/Dockerfile.armel
+++ b/scripts/build-targets/Dockerfile.armel
@@ -1,4 +1,4 @@
-FROM arm32v5/debian:bookworm
+FROM --platform=linux/arm/v5 debian:bookworm
 RUN apt-get update
 RUN apt-get -yy install \
     build-essential \


### PR DESCRIPTION
looks like Debian has set better manifest platform values, which
breaks our previous FROM usage (which was always wrong)