### PR TITLE
relative object sizes, plus a configurable reserved area at the top

### DIFF
--- a/src/front-lvgl.cpp
+++ b/src/front-lvgl.cpp
@@ -18,6 +18,8 @@
 #include <src/misc/lv_anim.h>
 #include <src/misc/lv_area.h>
 #include <src/misc/lv_style.h>
+#include <stdexcept>
+#include <string>
 
 // make sure these numbers align with SDL_HOR_RES/SDL_VER_RES
 #define MY_DISP_HOR_RES 800
@@ -249,11 +251,24 @@ void uithread(int _argc, char* _argv[])
 
   lv_obj_add_style(lv_scr_act(), &voorkant::lvgl::b612style, 0);
 
+  int32_t reserved_at_top = 0;
+  auto resvar = getenv("VOORKANT_LVGL_LINES_RESERVED_AT_TOP");
+
+  if (resvar != nullptr) {
+    reserved_at_top = std::stoi(resvar);
+    if (reserved_at_top < 0) {
+      throw std::runtime_error("can't reserve a negative amount of lines");
+    }
+  }
+
+  auto parent = lv_scr_act();
+
   /* container for object row (top 80% of screen) and logs (bottom 20%) */
-  lv_obj_t* row_and_logs = lv_obj_create(lv_scr_act());
+  lv_obj_t* row_and_logs = lv_obj_create(parent);
   lv_obj_remove_style_all(row_and_logs);
   lv_obj_remove_flag(row_and_logs, LV_OBJ_FLAG_SCROLLABLE);
-  lv_obj_set_size(row_and_logs, MY_DISP_HOR_RES, MY_DISP_VER_RES);
+  lv_obj_set_size(row_and_logs, lv_pct(100), lv_obj_get_height(parent) - reserved_at_top);
+  lv_obj_set_y(row_and_logs, reserved_at_top);
   lv_obj_set_flex_flow(row_and_logs, LV_FLEX_FLOW_ROW_WRAP);
 
   /*Create a container with ROW flex direction that wraps.
@@ -261,7 +276,7 @@ void uithread(int _argc, char* _argv[])
   */
   cont_row = lv_obj_create(row_and_logs);
   lv_obj_remove_style_all(cont_row);
-  lv_obj_set_size(cont_row, MY_DISP_HOR_RES, MY_DISP_VER_RES * 0.8);
+  lv_obj_set_size(cont_row, lv_pct(100), lv_pct(80));
   lv_obj_set_flex_flow(cont_row, LV_FLEX_FLOW_COLUMN_WRAP);
   lv_obj_set_style_pad_row(cont_row, 5, LV_PART_MAIN | LV_STATE_DEFAULT);
   lv_obj_set_style_pad_column(cont_row, 9, LV_PART_MAIN | LV_STATE_DEFAULT);
@@ -270,7 +285,7 @@ void uithread(int _argc, char* _argv[])
   /* Bottom row */
   lv_obj_t* bottom_row = lv_obj_create(row_and_logs);
   lv_obj_remove_style_all(bottom_row);
-  lv_obj_set_size(bottom_row, MY_DISP_HOR_RES, MY_DISP_VER_RES * 0.2);
+  lv_obj_set_size(bottom_row, lv_pct(100), lv_pct(20));
   lv_obj_set_align(bottom_row, LV_ALIGN_CENTER);
   lv_obj_set_flex_flow(bottom_row, LV_FLEX_FLOW_ROW);
   lv_obj_set_flex_align(bottom_row, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_START, LV_FLEX_ALIGN_END);

--- a/src/front-lvgl.cpp
+++ b/src/front-lvgl.cpp
@@ -11,12 +11,16 @@
 #include <src/core/lv_obj_pos.h>
 #include <src/core/lv_obj_scroll.h>
 #include <src/core/lv_obj_style.h>
+#include <src/core/lv_obj_style_gen.h>
+#include <src/display/lv_display.h>
 #include <src/font/lv_font.h>
 #include <src/font/lv_symbol_def.h>
 #include <src/indev/lv_indev.h>
+#include <src/layouts/grid/lv_grid.h>
 #include <src/libs/tiny_ttf/lv_tiny_ttf.h>
 #include <src/misc/lv_anim.h>
 #include <src/misc/lv_area.h>
+#include <src/misc/lv_color.h>
 #include <src/misc/lv_style.h>
 #include <stdexcept>
 #include <string>
@@ -261,14 +265,33 @@ void uithread(int _argc, char* _argv[])
     }
   }
 
-  auto parent = lv_scr_act();
+  static lv_obj_t* splitparent = lv_obj_create(lv_scr_act());
+  lv_obj_remove_style_all(splitparent);
+  lv_obj_remove_flag(splitparent, LV_OBJ_FLAG_SCROLLABLE);
+  lv_obj_set_size(splitparent, lv_pct(100), lv_pct(100));
+
+  lv_obj_set_layout(splitparent, LV_LAYOUT_GRID);
+  static lv_coord_t splitparent_col_dsc[] = {LV_GRID_FR(1), LV_GRID_TEMPLATE_LAST};
+  static lv_coord_t splitparent_row_dsc[] = {reserved_at_top, LV_GRID_FR(1), LV_GRID_TEMPLATE_LAST};
+  lv_obj_set_grid_dsc_array(splitparent, splitparent_col_dsc, splitparent_row_dsc);
+
+  static lv_obj_t* reserved = lv_obj_create(splitparent);
+  lv_obj_remove_style_all(reserved);
+  lv_obj_remove_flag(reserved, LV_OBJ_FLAG_SCROLLABLE);
+  lv_obj_set_grid_cell(reserved, LV_GRID_ALIGN_STRETCH, 0, 1, LV_GRID_ALIGN_STRETCH, 0, 1);
+  lv_obj_set_style_bg_opa(reserved, LV_OPA_TRANSP, 0);
+
+  static lv_obj_t* content = lv_obj_create(splitparent);
+  lv_obj_remove_style_all(content);
+  lv_obj_remove_flag(content, LV_OBJ_FLAG_SCROLLABLE);
+  lv_obj_set_grid_cell(content, LV_GRID_ALIGN_STRETCH, 0, 1, LV_GRID_ALIGN_STRETCH, 1, 1);
 
   /* container for object row (top 80% of screen) and logs (bottom 20%) */
-  lv_obj_t* row_and_logs = lv_obj_create(parent);
+  lv_obj_t* row_and_logs = lv_obj_create(content);
   lv_obj_remove_style_all(row_and_logs);
   lv_obj_remove_flag(row_and_logs, LV_OBJ_FLAG_SCROLLABLE);
-  lv_obj_set_size(row_and_logs, lv_pct(100), lv_obj_get_height(parent) - reserved_at_top);
-  lv_obj_set_y(row_and_logs, reserved_at_top);
+  lv_obj_set_size(row_and_logs, lv_pct(100), lv_pct(100));
+  // lv_obj_set_y(row_and_logs, reserved_at_top);
   lv_obj_set_flex_flow(row_and_logs, LV_FLEX_FLOW_ROW_WRAP);
 
   /*Create a container with ROW flex direction that wraps.


### PR DESCRIPTION
the reserved area at the top should (once we stop painting it white)
allow us to run "inside" Toon's qt-gui

this replaces the (already closed) #143 and already does better.
Next steps:
* instead of manually calculating our size minus the reservation, plus our y coordinate, use a parent lvgl object that holds $reserved rows and passes the rest to our row_and_logs
* deal with transparency or whatever so we never ever draw a pixel to the reserved area

Next steps for likely a later PR:
* for toon, we don't need 55 lines, we just need the rectangle for the back button on the top left. Likely we can put some fun status bar on the right 80% of those 55 lines