### PR TITLE
openwrt package and GH workflow

### DIFF
--- a/.github/workflows/main-openwrt.yml
+++ b/.github/workflows/main-openwrt.yml
@@ -1,0 +1,63 @@
+name: Build for armel (static) using the OpenWrt SDK
+
+on:
+  push:
+  pull_request:
+  schedule:
+    # Weekly build (on saturday)
+    - cron: '0 0 * * 4'
+
+jobs:
+  build-armel-owrt:
+    runs-on: 'ubuntu-24.04'
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        submodules: recursive
+    - name: install extra deps for nektos/act
+      if: ${{ env.ACT }}
+      run: |
+        sudo apt-get update
+        sudo apt-get -y install rsync
+    - name: Get the SDK
+      run: |
+        # in December 2024/January 2025, https://downloads.openwrt.org/snapshots/targets/mxs/generic/openwrt-sdk-mxs-generic_gcc-13.3.0_musl_eabi.Linux-x86_64.tar.zst
+        # (master snapshot) worked too, but I prefer a more stable target. The resulting binary was 8 kbytes smaller on master at the time.
+        wget --progress=dot:giga https://downloads.openwrt.org/releases/24.10.0-rc4/targets/mxs/generic/openwrt-sdk-24.10.0-rc4-mxs-generic_gcc-13.3.0_musl_eabi.Linux-x86_64.tar.zst
+        tar xf openwrt-sdk-*.tar.zst
+        rm -f openwrt-sdk-*.tar.zst
+        mv openwrt-sdk-* ../sdk
+    - name: Set up package dir
+      run: |
+        cd ../sdk
+        mkdir -p ../package/voorkant
+        # I used symlinks in an earlier iteration, which failed because the package dir was inside. Might be an interesting optimisation, please test in GH Actions -and- act if you try symlinks here.
+        cp "${GITHUB_WORKSPACE}"/openwrt-package/voorkant/Makefile ../package/voorkant/ # I guess this could be a recursive copy instead, in case we add files/ at some point
+        cp -fpR "${GITHUB_WORKSPACE}" ../package/voorkant/src
+        ( echo "src-link voorkant ${GITHUB_WORKSPACE}/../package" ; cat feeds.conf.default ) > feeds.conf
+    - name: Update packages feed
+      run: |
+        cd "../sdk"
+        scripts/feeds update packages
+        scripts/feeds update base
+        scripts/feeds update voorkant
+        cd feeds/packages && patch -p1 < ${GITHUB_WORKSPACE}/openwrt-package/libcurl-websockets.patch
+    - name: Build package
+      run: |
+        set -x
+        cd "../sdk"
+        scripts/feeds install -f voorkant
+        cat ${GITHUB_WORKSPACE}/openwrt-package/default-dot-config >> .config
+        make defconfig
+        make -j$(nproc) V=s package/voorkant/compile
+        make -j1 V=s package/index
+    - name: Prepare artifact
+      run: |
+        cd ../sdk
+        find bin/packages/ -ls
+        tar cf ${GITHUB_WORKSPACE}/packages.tar bin/packages/ .config
+    # FIXME: put something useful (git hash?) in artifact name. We also want this in other workflows.
+    - uses: actions/upload-artifact@v4
+      with:
+        name: openwrt-armel-build
+        path: packages.tar

--- a/meson.build
+++ b/meson.build
@@ -168,9 +168,6 @@ endif
 
 incdir = include_directories('./src/')
 
-openssl_dep = dependency('openssl')
-zlib_dep = dependency('zlib')
-
 if get_option('front-ftxui').enabled()
     ftxui_screen_dep = dependency('ftxui-screen')
     ftxui_dom_dep = dependency('ftxui-dom')
@@ -196,8 +193,6 @@ if get_option('front-ftxui').enabled()
             ftxui_screen_dep,
             ftxui_dom_dep,
             ftxui_component_dep,
-            openssl_dep,
-            zlib_dep,
             libatomic,
         ],
     )
@@ -221,8 +216,6 @@ executable(
         json_dep,
         thread_dep,
         curl_dep,
-        openssl_dep,
-        zlib_dep,
         libatomic,
     ],
 )
@@ -261,8 +254,6 @@ if get_option('front-lvgl').enabled()
             curl_dep,
             lvgl_dep,
             sdl2_dep,
-            openssl_dep,
-            zlib_dep,
             libatomic,
             date_dep,
             quickjs_dep,

--- a/openwrt-package/default-dot-config
+++ b/openwrt-package/default-dot-config
@@ -1,0 +1,9 @@
+CONFIG_SIGNED_PACKAGES=n
+
+CONFIG_LIBCURL_WEBSOCKETS=y
+
+# we can =n a lot more things, and the list might grow over time
+CONFIG_LIBCURL_NGHTTP2=n
+
+# remove this once curl is upgraded to 8.11
+CONFIG_LIBCURL_VERBOSE=y

--- a/openwrt-package/libcurl-websockets.patch
+++ b/openwrt-package/libcurl-websockets.patch
@@ -1,0 +1,43 @@
+commit 805f0bbc7f3dfb3ca10d598b9ac53e09c9ecfaaf
+Author: Peter van Dijk <peter@7bits.nl>
+Date:   Wed Jan 1 20:15:07 2025 +0100
+
+    curl: add LIBCURL_WEBSOCKETS flag
+    
+    Signed-off-by: Peter van Dijk <peter@7bits.nl>
+
+diff --git a/net/curl/Config.in b/net/curl/Config.in
+index 29865a87a..04f03a5bd 100644
+--- a/net/curl/Config.in
++++ b/net/curl/Config.in
+@@ -45,6 +45,10 @@ config LIBCURL_HTTP
+ 	bool "HTTP / HTTPS protocol"
+ 	default y
+ 
++config LIBCURL_WEBSOCKETS
++	bool "WebSockets protocol"
++	default n
++
+ config LIBCURL_COOKIES
+ 	bool "Enable Cookies support"
+ 	depends on LIBCURL_HTTP
+diff --git a/net/curl/Makefile b/net/curl/Makefile
+index 5210f8c8d..fe529fa41 100644
+--- a/net/curl/Makefile
++++ b/net/curl/Makefile
+@@ -44,6 +44,7 @@ PKG_CONFIG_DEPENDS:= \
+   CONFIG_LIBCURL_FTP \
+   CONFIG_LIBCURL_GOPHER \
+   CONFIG_LIBCURL_HTTP \
++  CONFIG_LIBCURL_WEBSOCKETS \
+   CONFIG_LIBCURL_IMAP \
+   CONFIG_LIBCURL_LDAP \
+   CONFIG_LIBCURL_LDAPS \
+@@ -153,6 +154,7 @@ CONFIGURE_ARGS += \
+ 	$(call autoconf_bool,CONFIG_LIBCURL_SMTP,smtp) \
+ 	$(call autoconf_bool,CONFIG_LIBCURL_TELNET,telnet) \
+ 	$(call autoconf_bool,CONFIG_LIBCURL_TFTP,tftp) \
++	$(call autoconf_bool,CONFIG_LIBCURL_WEBSOCKETS,websockets) \
+ 	\
+ 	$(call autoconf_bool,CONFIG_LIBCURL_COOKIES,cookies) \
+ 	$(call autoconf_bool,CONFIG_LIBCURL_CRYPTO_AUTH,crypto-auth) \

--- a/openwrt-package/voorkant/Makefile
+++ b/openwrt-package/voorkant/Makefile
@@ -1,0 +1,36 @@
+# FIXME: license text here
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=voorkant
+PKG_RELEASE:=0_git
+
+PKG_LICENSE:=MIT
+
+PKG_BUILD_DEPENDS:=curl nlohmannjson
+
+include $(INCLUDE_DIR)/package.mk
+include $(INCLUDE_DIR)/meson.mk
+
+define Package/voorkant
+  SECTION:=utils
+  CATEGORY:=Utilities
+  TITLE:=Non-web Home Assistant frontend
+endef
+
+define Package/voorkant/description
+  FIXME
+endef
+
+define Package/voorkant/install
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/openwrt-build/voorkant-lvgl $(1)/usr/bin/
+endef
+
+MESON_ARGS += \
+	--prefer-static -Dlvgl-driver=fbdev -Dfront-ftxui=disabled
+
+# FIXME: we should not need most, maybe all, of these
+TARGET_LDFLAGS += -latomic -static -lstdc++ -lgcc_eh
+
+$(eval $(call BuildPackage,voorkant))


### PR DESCRIPTION
This currently sits on top of #145 

TODO:
* [ ] [bumping curl in openwrt](https://github.com/openwrt/packages/pull/25397) would be cool as we can then use websockets without spending space on verbose messages
* [ ] add websocket support to the openwrt curl package (https://github.com/openwrt/packages/pull/25654) (this PR currently works around this by patching the package)
* [x] upstream, or patch on our end, the quickjs-ng fenv stuff (https://git.musl-libc.org/cgit/musl/tree/arch/arm/bits/fenv.h). fixed: upstream already did it! #147
* [ ] figure out if, and why, we need all of `TARGET_LDFLAGS += -latomic -static -lstdc++ -lgcc_eh`. Especially that last one feels so wrong.