### PR TITLE
hinnant-date: set use_system_tzdb

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -221,7 +221,10 @@ executable(
 )
 
 if get_option('front-lvgl').enabled()
-    date_dep = dependency('date', default_options: ['default_library=static'])
+    date_dep = dependency(
+        'date',
+        default_options: ['default_library=static', 'use_system_tzdb=true'],
+    )
 
     executable(
         'voorkant-lvgl',


### PR DESCRIPTION
This fixes compilation on Haiku, and, I bet, also on a few other systems that don't have wordexp.h

Incidentally I never wanted this lib to go looking for a TZDB online, so this change is good in more ways than one.
