### PR TITLE
voorkant-cli subscribe: emit json

### DIFF
--- a/src/front-cli.cpp
+++ b/src/front-cli.cpp
@@ -32,6 +32,7 @@ public:
   {
     g_log << Logger::Debug << "Received uiupdate for " << haentity->name << ":" << std::endl;
     g_log << Logger::Debug << haentity->getInfo() << std::endl;
+    cout << haentity->getJsonState() << std::endl;
   }
 
 private:

--- a/src/front-cli.cpp
+++ b/src/front-cli.cpp
@@ -84,7 +84,7 @@ void uithread(int _argc, char* _argv[])
     // FIXME: now actually use the argument
     string domain = subscribe_command.get<string>("domain");
     if (!domain.empty()) {
-      cout << "should subscribe to " << subscribe_command.get<string>("domain") << endl;
+      cerr << "should subscribe to " << subscribe_command.get<string>("domain") << endl;
     }
     else {
       cerr << "No domain provided!" << endl;


### PR DESCRIPTION
example usage to get just light brightness, real time, one line with one number on it per update:
    
```
build/voorkant-cli subscribe light 2> /dev/null | jq 'if .entity_id == "light.plafondlamp_kantoor_peter_level_light_color_on_off" then .attributes.brightness/2.55 else null end | select(.!=null)'
```
